### PR TITLE
[Yang-soeun] step-1: index.html 응답

### DIFF
--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -1,10 +1,8 @@
 package webserver;
 
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.net.Socket;
+import java.nio.file.Files;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,6 +11,11 @@ public class RequestHandler implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
 
     private Socket connection;
+    private static final int PATH_POS = 1;
+    private static final int EXTENSION_POS = 1;
+    private static final String END = "";
+    private static final String PATH_DELIMITER = " ";
+    private static final String EXTENSION_DELIMITER = "/";
 
     public RequestHandler(Socket connectionSocket) {
         this.connection = connectionSocket;
@@ -24,19 +27,32 @@ public class RequestHandler implements Runnable {
 
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
             // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
+            BufferedReader br = new BufferedReader(new InputStreamReader(in, "UTF-8"));
+            String request = br.readLine();
+            logger.debug(request);
+
+            String path = request.split(PATH_DELIMITER)[PATH_POS];
+            String extension = path.split(EXTENSION_DELIMITER)[EXTENSION_POS];
+            System.out.println(extension);
+
+            while(!request.equals(END)){
+                request = br.readLine();
+                logger.debug(request);
+            }
+
             DataOutputStream dos = new DataOutputStream(out);
-            byte[] body = "Hello World".getBytes();
-            response200Header(dos, body.length);
+            byte[] body = Files.readAllBytes(new File(ResponseEnum.getPathName(extension) + path).toPath());
+            response200Header(dos, body.length, ResponseEnum.getContentType(extension));
             responseBody(dos, body);
         } catch (IOException e) {
             logger.error(e.getMessage());
         }
     }
 
-    private void response200Header(DataOutputStream dos, int lengthOfBodyContent) {
+    private void response200Header(DataOutputStream dos, int lengthOfBodyContent, String contentType) {
         try {
             dos.writeBytes("HTTP/1.1 200 OK \r\n");
-            dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
+            dos.writeBytes("Content-Type: " + contentType + ";charset=utf-8\r\n");
             dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
             dos.writeBytes("\r\n");
         } catch (IOException e) {

--- a/src/main/java/webserver/ResponseEnum.java
+++ b/src/main/java/webserver/ResponseEnum.java
@@ -1,0 +1,38 @@
+package webserver;
+
+public enum ResponseEnum {
+    HTML("index.html", "src/main/resources/templates", "text/html"),
+    CSS("css", "src/main/resources/static", "text/css"),
+    JS("js", "src/main/resources/static","application/javascript"),
+    FONTS("fonts", "src/main/resources/static","font/ttf");
+    private final String extension;
+    private final String pathName;
+    private final String contentType;
+
+    private static final String NONE = "없음";
+
+    ResponseEnum(String extension, String pathName, String contentType) {
+        this.extension = extension;
+        this.pathName = pathName;
+        this.contentType = contentType;
+    }
+
+    public static String getPathName(String extension) {
+        for (ResponseEnum responseEnum : values()) {
+            if (responseEnum.extension.equals(extension)) {
+                return responseEnum.pathName;
+            }
+        }
+        return NONE;
+    }
+
+    public static String getContentType(String extension) {
+        for (ResponseEnum responseEnum : values()) {
+            if (responseEnum.extension.equals(extension)) {
+                return responseEnum.contentType;
+            }
+        }
+        return NONE;
+    }
+
+}


### PR DESCRIPTION
## 구현 내용

- 서버로 들어오는 HTTP Request의 내용을 읽고 로거(log.debug)를 이용해 출력
- path에 해당하는 파일 읽어 응답하기

## 고민 사항
1. contentType 문제
- 처음에 request Line에서 path를 분리하여 해당하는 파일을 읽도록 구현하였으나, css 적용되지 않았다.
- 이유는 contentType text/html로 되어 있어서 적용되지 않았던 것이다.
2. contentType, pathname 지정
- 위의 문제를 해결하기 위해 request를 보고 css, html, js 등을 구별하여 맞는 contentType과  pathname을 지정해줘야 했다. 그러다 보니 if 문이 많아져서 고민이 생겼다.
- 이를 해결하기 위해서 enum을 활용해서 path에서 확장자를 이용해 해당하는 타입과, pathname을 가져오도록 코드를 수정하였다.
- 현재 생각나는 방법이 enum이여서 enum으로 했는데 다른 좋은 방법을 고민해 보고 코드를 다시 수정해야겠다.

## 기타
- 매직 넘버를 사용하지 않으려고 노력했다.
- Java Thread 기반으로 작성되어 있는 부분을 Concurrent 패키지를 사용하도록 변경하기 위해서 Concurrent 패키지를 먼저 공부 하고 해야겠다.
- enum 클래스의 이름으로 어떤게 좋을지 아직도 고민이다...