### PR TITLE
[timido7021] step-1 index.html 정적인 html 응답 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,55 @@ Java Web Application Server 2023
 
 이 프로젝트는 우아한 테크코스 박재성님의 허가를 받아 https://github.com/woowacourse/jwp-was 
 를 참고하여 작성되었습니다.
+
+## 학습 내용
+
+### 정적인 html 파일 응답, HTTP Request 내용 출력
+
+- InputStream을 InputStreamReader - BufferedReader를 통해 라인별로 http header를 읽을 수 있음.
+- String.split 메소드를 통해 Header의 첫 라인에서 요청 URL을 알 수 있음.
+- Files, Path를 통해 지정된 경로를 통해 바이트 형식으로 파일을 읽을 수 있음.
+
+### Java Thread에 대해
+
+[출처1](https://letsmakemyselfprogrammer.tistory.com/98)
+
+[출처2](https://e-una.tistory.com/70)
+
+[출처3](https://emong.tistory.com/221)
+
+스레드는 OS가 관리하는가, User가 관리하는가에 따라 Kernel-level, User-level로 구분된다.
+
+현재 자바에서는 Native Thread라는 다대다 모델로서 OS수준에서 구현되고 관리된다.
+
+이는 더 정확한 동시성 처리와 멀티 코어 시스템을 활용하는 장점이 있지만 동기화 및 자원 공유가 복잡해서 실행 시간이 증가한다는 단점이 있다.
+
+자바는 Runnable 인터페이스를 통해 문법적으로 스레드를 지원하고 run 메소드를 가진다.
+
+Thread를 이용하게 되면 코드에 중복 부분이 생기고 에러가 나기 쉽다. 이러한 이유로 자바 5에서 Concurrency API가 소개되었다.
+
+이후 자바 8에서 다양한 클래스와 메소드를 이용해서 프로그래머가 스레드를 활용한 병렬성을 다룰 수 있게 되었다.
+
+### Java Concurrent Package에 대해
+
+Concurrent API는 ExecutorService라는 개념으로 Thread를 대체한다.
+
+Executor는 작업(task)를 비동기적으로 실행시킬 수 있고 스레드 풀을 기본적으로 운영한다.
+
+따라서 프로그래머는 스레드를 직접 만들지 않아도 되고, 자연스럽게 임무를 마친 스레드를 재사용하게 된다.
+
+이러한 ExecutorService를 이용해서 프로그래머가 원하는 만큼 병렬 Task를 만들고 실행시킨다.
+
+또한 Callable을 통해 반환 값을 받을 수 있는 스레드를 생성할 수 있다.
+
+Timeout, Future, ScheduledExecutor 등의 개념들도 프로그래머가 더 효과적으로 병렬 Task를 다룰 수 있게 한다.
+
+### Java Thread에서 Concurrent 패키지로의 변경
+
+WebServer.java 부분에서 기존의 Thread로 구현된 부분을 다음과 같은 코드로 변경하였다.
+
+`ExecutorService threadPool = Executors.newFixedThreadPool(4);`
+
+`threadPool.submit(new RequestHandler(connection));`
+
+따라서 기존의 Thread 방식에선 호출될 때마다 스레드를 생성하였다면 Concurrent 패키지를 통해 4개의 스레드를 가진 스레드 풀을 지정하여 다 쓰인 스레드를 재사용하도록 하였다.

--- a/src/main/java/utils/HttpHeaderUtil.java
+++ b/src/main/java/utils/HttpHeaderUtil.java
@@ -2,50 +2,52 @@ package utils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import webserver.RequestHandler;
 
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 
 public class HttpHeaderUtil {
     private static final Logger logger = LoggerFactory.getLogger(HttpHeaderUtil.class);
 
-    public static String[] getHttpMethodAndUrl(BufferedReader bufferedReader) throws IOException{
+    public static String[] getHttpMethodAndUrl(BufferedReader bufferedReader) throws IOException {
+        String httpRequest = bufferedReader.readLine().trim();
+        String[] httpRequestTokens = httpRequest.split(" ");
+        String httpMethod = httpRequestTokens[0];
+        String requestUrl = httpRequestTokens[1];
+
+        logger.debug("HTTP Method: " + httpMethod);
+        logger.debug("HTTP Request URL: " + requestUrl);
+
         String requestHeaderLine = "";
-        String httpMethod = "";
-        String requestUrl = "";
 
         while (!(requestHeaderLine = bufferedReader.readLine().trim()).isEmpty()) {
-            logger.debug(requestHeaderLine);
-
-            String[] tokens = requestHeaderLine.split(" ");
-            if (tokens[0].equals("GET")
-                    || tokens[0].equals("POST")) {
-                httpMethod = tokens[0];
-                requestUrl = tokens[1];
-            }
+            if (
+                    requestHeaderLine.startsWith("Host: ")
+                    || requestHeaderLine.startsWith("Connection: ")
+                    || requestHeaderLine.startsWith("Accept")
+                    || requestHeaderLine.startsWith("User-Agent: ")
+                    || requestHeaderLine.startsWith("Referer: ")
+            )
+                logger.debug(requestHeaderLine);
         }
 
-        String[] result = {httpMethod, requestUrl};
-        return result;
+        return httpRequestTokens;
     }
 
     public static String getContentType(String requestedUrl) {
         Path source = Paths.get(requestedUrl);
         try {
-            String mimeType = Files.probeContentType(source);
-            if (mimeType == null) {
+            String contentType = Files.probeContentType(source);
+            if (contentType == null) {
                 if (requestedUrl.endsWith(".woff"))
-                    mimeType = "font/woff";
+                    contentType = "font/woff";
                 else
                     throw new Exception("cannot determine content-type.");
             }
-            return mimeType;
+            return contentType;
         } catch (Exception e) {
             logger.error(e.getMessage());
             return "text/plain";

--- a/src/main/java/utils/HttpHeaderUtil.java
+++ b/src/main/java/utils/HttpHeaderUtil.java
@@ -1,0 +1,54 @@
+package utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import webserver.RequestHandler;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+
+public class HttpHeaderUtil {
+    private static final Logger logger = LoggerFactory.getLogger(HttpHeaderUtil.class);
+
+    public static String[] getHttpMethodAndUrl(BufferedReader bufferedReader) throws IOException{
+        String requestHeaderLine = "";
+        String httpMethod = "";
+        String requestUrl = "";
+
+        while (!(requestHeaderLine = bufferedReader.readLine().trim()).isEmpty()) {
+            logger.debug(requestHeaderLine);
+
+            String[] tokens = requestHeaderLine.split(" ");
+            if (tokens[0].equals("GET")
+                    || tokens[0].equals("POST")) {
+                httpMethod = tokens[0];
+                requestUrl = tokens[1];
+            }
+        }
+
+        String[] result = {httpMethod, requestUrl};
+        return result;
+    }
+
+    public static String getContentType(String requestedUrl) {
+        Path source = Paths.get(requestedUrl);
+        try {
+            String mimeType = Files.probeContentType(source);
+            if (mimeType == null) {
+                if (requestedUrl.endsWith(".woff"))
+                    mimeType = "font/woff";
+                else
+                    throw new Exception("cannot determine content-type.");
+            }
+            return mimeType;
+        } catch (Exception e) {
+            logger.error(e.getMessage());
+            return "text/plain";
+        }
+    }
+}

--- a/src/main/java/utils/HttpHeaderUtil.java
+++ b/src/main/java/utils/HttpHeaderUtil.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.StringTokenizer;
 
 public class HttpHeaderUtil {
     private static final Logger logger = LoggerFactory.getLogger(HttpHeaderUtil.class);
@@ -21,21 +22,47 @@ public class HttpHeaderUtil {
         logger.debug("HTTP Method: " + httpMethod);
         logger.debug("HTTP Request URL: " + requestUrl);
 
-        String requestHeaderLine = "";
-
-        while (!(requestHeaderLine = bufferedReader.readLine().trim()).isEmpty()) {
-            if (
-                    requestHeaderLine.startsWith("Host: ")
-                    || requestHeaderLine.startsWith("Connection: ")
-                    || requestHeaderLine.startsWith("Accept")
-                    || requestHeaderLine.startsWith("User-Agent: ")
-                    || requestHeaderLine.startsWith("Referer: ")
-            )
-                logger.debug(requestHeaderLine);
-        }
+        logHeaderInfo(bufferedReader);
 
         return httpRequestTokens;
     }
+
+    private static void logHeaderInfo(BufferedReader bufferedReader) throws IOException {
+        String requestHeaderLine = "";
+        String headerContent = "";
+
+        while (!(requestHeaderLine = bufferedReader.readLine().trim()).isEmpty()) {
+            if (requestHeaderLine.startsWith("Host: ")) {
+                headerContent = requestHeaderLine.substring("Host: ".length());
+                logger.debug("요청하는 호스트의 이름과 포트번호: " + headerContent);
+            }
+            if (requestHeaderLine.startsWith("Connection: ")) {
+                headerContent = requestHeaderLine.substring("Connection: ".length());
+                logger.debug("현재 연결을 유지한 채로 HTTP 통신을 주고 받을 것인지(close, keep-alive): " + headerContent);
+            }
+            if (requestHeaderLine.startsWith("Referer: ")) {
+                headerContent = requestHeaderLine.substring("Referer: ".length());
+                logger.debug("직전에 머물었던 URL: " + headerContent);
+            }
+            if (requestHeaderLine.startsWith("User-Agent: ")) {
+                headerContent = requestHeaderLine.substring("User-Agent: ".length());
+                logger.debug("클라이언트 웹 브라우저 명칭 및 버전 정보: " + headerContent);
+            }
+            if (requestHeaderLine.startsWith("Accept: ")) {
+                headerContent = requestHeaderLine.substring("Accept: ".length());
+                logger.debug("클라이언트가 원하는 미디어 타입 및 우선순위: " + headerContent);
+            }
+            if (requestHeaderLine.startsWith("Accept-Encoding: ")) {
+                headerContent = requestHeaderLine.substring("Accept-Encoding: ".length());
+                logger.debug("클라이언트가 원하는 문자 인코딩 방식: " + headerContent);
+            }
+            if (requestHeaderLine.startsWith("Accept-Language: ")) {
+                headerContent = requestHeaderLine.substring("Accept-Language: ".length());
+                logger.debug("클라이언트가 원하는 언어: " + headerContent);
+            }
+        }
+    }
+
 
     public static String getContentType(String requestedUrl) {
         Path source = Paths.get(requestedUrl);

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -1,10 +1,9 @@
 package webserver;
 
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.net.Socket;
+import java.nio.file.Files;
+import java.util.Arrays;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,20 +22,65 @@ public class RequestHandler implements Runnable {
                 connection.getPort());
 
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
+            BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(in));
+
+            String requestHeaderLine = "";
+            String method = "";
+            String requestUrl = "";
+
+            while (!(requestHeaderLine = bufferedReader.readLine().trim()).isEmpty()) {
+                logger.debug(requestHeaderLine);
+
+                String[] tokens = requestHeaderLine.split(" ");
+                if (tokens[0].equals("GET")
+                        || tokens[0].equals("POST")) {
+                    method = tokens[0];
+                    requestUrl = tokens[1];
+                }
+            }
+
             // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
+
             DataOutputStream dos = new DataOutputStream(out);
-            byte[] body = "Hello World".getBytes();
-            response200Header(dos, body.length);
+            byte[] body;
+            String contentType;
+            if (method.equals("GET")) {
+                if (requestUrl.equals("/index.html")) {
+                    body = Files.readAllBytes(
+                            new File("./src/main/resources/templates" + requestUrl).toPath());
+                    contentType = "text/html";
+                }
+                else  {
+                    body = Files.readAllBytes(
+                            new File("./src/main/resources/static" + requestUrl).toPath());
+
+                    if (requestUrl.endsWith(".js"))
+                        contentType = "text/javascript";
+                    else if (requestUrl.endsWith(".css"))
+                        contentType = "text/css";
+                    else if (requestUrl.endsWith(".ico"))
+                        contentType = "image/vnd.microsoft.icon";
+                    else if (requestUrl.endsWith(".ttf"))
+                        contentType = "text/ttf";
+                    else
+                        contentType = "text/plain";
+                }
+            } else {
+                body = "Hello World".getBytes();
+                contentType = "text/html";
+            }
+
+            response200Header(dos, body.length, contentType);
             responseBody(dos, body);
         } catch (IOException e) {
             logger.error(e.getMessage());
         }
     }
 
-    private void response200Header(DataOutputStream dos, int lengthOfBodyContent) {
+    private void response200Header(DataOutputStream dos, int lengthOfBodyContent, String contentType) {
         try {
             dos.writeBytes("HTTP/1.1 200 OK \r\n");
-            dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
+            dos.writeBytes(String.format("Content-Type: %s;charset=utf-8\r\n", contentType));
             dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
             dos.writeBytes("\r\n");
         } catch (IOException e) {

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -2,6 +2,9 @@ package webserver;
 
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,12 +24,12 @@ public class WebServer {
         // 서버소켓을 생성한다. 웹서버는 기본적으로 8080번 포트를 사용한다.
         try (ServerSocket listenSocket = new ServerSocket(port)) {
             logger.info("Web Application Server started {} port.", port);
+            ExecutorService threadPool = Executors.newFixedThreadPool(4);
 
             // 클라이언트가 연결될때까지 대기한다.
             Socket connection;
             while ((connection = listenSocket.accept()) != null) {
-                Thread thread = new Thread(new RequestHandler(connection));
-                thread.start();
+                threadPool.submit(new RequestHandler(connection));
             }
         }
     }


### PR DESCRIPTION
## 구현 내용
1. /index.html로 접속하였을 때 resources/templates/index.html를 바이트로 읽어서 클라이언트에게 반환한다.
1. 서버로 들어오는 HTTP 요청을 라인 별로 Logger에 출력하였다.
1. 기존 Thread기반으로 작성된 부분을 Concurrent 패키지를 사용하도록 변경했다.

## 고민 사항
- 클라이언트가 index.html을 요청할 때 css, js, 폰트 등을 같이 요청하는데, 이 때 Content-Type을 해당 리소스에 맞게 응답 헤더에 적어야했다. 따라서 이 부분을 구현하도록 헤더를 작성하는 메소드를 변경하고 HTTP Method와 URL을 알아내는 메소드, Content-Type을 url로 부터 알 수 있는 메소드를 작성하였다. 
- 다만 코드를 작성하는 과정에서 깔끔하지 않고 if문을 많이 사용해서 이 부분을 어떻게 수정할 지 고민해봐야겠다.

## 기타
- woff 확장자를 인식하지 못해 별도로 Content-Type을 넣었다.
- header와 관련된 부분을 utils로 분리하였는데, RequestHandler에 남아있는 기능들 중 더 분리할 수 있는 부분을 찾아봐야겠다.
- Thread, Concurrent 패키지에 대해 조금이나마 알게 된 기회였다.
- 전체적인 프로젝트 구조를 잡아야 코딩할 때, 코드를 리뷰할 때 편할 것 같다.