### PR TITLE
[Yoon-Suji] step-1: index.html 응답 구현

### DIFF
--- a/src/main/java/webserver/HttpRequestParam.java
+++ b/src/main/java/webserver/HttpRequestParam.java
@@ -1,0 +1,42 @@
+package webserver;
+
+public class HttpRequestParam {
+    private final String method;
+
+    private final String uri;
+    private String path;
+
+    private String contentType;
+
+    public HttpRequestParam(String method, String uri) {
+        this.method = method;
+        this.uri = uri;
+        parseUri(uri);
+    }
+
+    public String getMethod() {
+        return this.method;
+    }
+
+    public String getUri() {
+        return this.uri;
+    }
+
+    public String getPath() {
+        return this.path;
+    }
+
+    public String getContentType() {
+        return this.contentType;
+    }
+
+    void parseUri(String uri) {
+        String[] parsedUri = uri.split("\\.");
+        this.contentType = parsedUri[parsedUri.length - 1];
+        if (this.contentType.equals("html")) {
+            this.path = "./src/main/resources/templates" + this.uri;
+        } else {
+            this.path = "./src/main/resources/static" + this.uri;
+        }
+    }
+}

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -1,10 +1,8 @@
 package webserver;
 
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.net.Socket;
+import java.nio.file.Files;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,7 +10,7 @@ import org.slf4j.LoggerFactory;
 public class RequestHandler implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
 
-    private Socket connection;
+    private final Socket connection;
 
     public RequestHandler(Socket connectionSocket) {
         this.connection = connectionSocket;
@@ -24,19 +22,26 @@ public class RequestHandler implements Runnable {
 
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
             // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
+            HttpRequestParam request = WebUtil.HttpRequestParse(in, logger);
             DataOutputStream dos = new DataOutputStream(out);
-            byte[] body = "Hello World".getBytes();
-            response200Header(dos, body.length);
+            byte[] body = null;
+            try {
+                body = Files.readAllBytes(new File(request.getPath()).toPath());
+            } catch (Exception e) {
+                logger.error(e.getMessage());
+                body = "<h1>Hello, Suji👋</h1>".getBytes();
+            }
+            response200Header(dos, body.length, "text/" + request.getContentType());
             responseBody(dos, body);
         } catch (IOException e) {
             logger.error(e.getMessage());
         }
     }
 
-    private void response200Header(DataOutputStream dos, int lengthOfBodyContent) {
+    private void response200Header(DataOutputStream dos, int lengthOfBodyContent, String contentType) {
         try {
             dos.writeBytes("HTTP/1.1 200 OK \r\n");
-            dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
+            dos.writeBytes("Content-Type: " + contentType + ";charset=utf-8\r\n");
             dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
             dos.writeBytes("\r\n");
         } catch (IOException e) {

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -2,6 +2,8 @@ package webserver;
 
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,12 +24,21 @@ public class WebServer {
         try (ServerSocket listenSocket = new ServerSocket(port)) {
             logger.info("Web Application Server started {} port.", port);
 
-            // 클라이언트가 연결될때까지 대기한다.
+            ExecutorService executorService = Executors.newFixedThreadPool(10);
+
             Socket connection;
+            // concurrent 패키지를 사용한 코드
             while ((connection = listenSocket.accept()) != null) {
-                Thread thread = new Thread(new RequestHandler(connection));
-                thread.start();
+                executorService.submit(new RequestHandler(connection));
             }
+
+            // 클라이언트가 연결될때까지 대기한다.
+            // Thread를 직접 사용한 기존 코드
+//            Socket connection;
+//            while ((connection = listenSocket.accept()) != null) {
+//                Thread thread = new Thread(new RequestHandler(connection));
+//                thread.start();
+//            }
         }
     }
 }

--- a/src/main/java/webserver/WebUtil.java
+++ b/src/main/java/webserver/WebUtil.java
@@ -1,0 +1,30 @@
+package webserver;
+
+import org.slf4j.Logger;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+public class WebUtil {
+    public static HttpRequestParam HttpRequestParse(InputStream request, Logger logger) {
+        BufferedReader br = new BufferedReader(new InputStreamReader(request));
+        String line = null;
+        HttpRequestParam parsedRequest = null;
+        try {
+            line = br.readLine();
+            String[] tokens = line.split(" ");
+            parsedRequest = new HttpRequestParam(tokens[0], tokens[1]);
+            logger.debug("HTTP Request Header >> " + line);
+//            while (line != null && !line.isEmpty()) {
+//                logger.debug(line);
+//                line = br.readLine();
+//            }
+            return parsedRequest;
+        } catch (IOException e) {
+            logger.error(e.getMessage());
+        }
+        return parsedRequest;
+    }
+}

--- a/src/test/java/webserver/WebUtilTest.java
+++ b/src/test/java/webserver/WebUtilTest.java
@@ -1,0 +1,35 @@
+package webserver;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+public class WebUtilTest {
+    private static final Logger logger = LoggerFactory.getLogger(WebServer.class);
+
+    @Test
+    @DisplayName("HttpRequestParser Test")
+    public void HttpRequestParseTest() {
+        // given
+        String mockRequest = "GET /index.html HTTP/1.1\n" +
+                "Host: localhost:8080\n" +
+                "Connection: keep-alive\n" +
+                "Accept: */*";
+        InputStream inputStream = new ByteArrayInputStream(mockRequest.getBytes());
+
+        // when
+        HttpRequestParam parsedRequest = WebUtil.HttpRequestParse(inputStream, logger);
+
+        // then
+        Assertions.assertThat(parsedRequest.getMethod()).isEqualTo("GET");
+        Assertions.assertThat(parsedRequest.getUri()).isEqualTo("/index.html");
+        Assertions.assertThat(parsedRequest.getPath()).isEqualTo("./src/main/resources/templates/index.html");
+        Assertions.assertThat(parsedRequest.getContentType()).isEqualTo("html");
+
+    }
+}


### PR DESCRIPTION
## 구현 내용
### 1. 정적인 html 파일 응답
http://localhost:8080/index.html 로 접속했을 때 src/main/resources/templates 디렉토리의 index.html 파일을 읽어 클라이언트에 응답한다.
* HTTP Request에서 Method와 URI를 파싱하는 기능을 하는 메소드를 **`WebUtil` 클래스 안의 `HttpRequestParse` static 메소드로 구현**
* 데이터 전달을 용이하게 하기 위해 **`HttpRequestParam` 객체**를 만들어 사용
* `HttpRequestParam`을 생성할 때 uri에서 path와 contentType을 파싱해서 저장하도록 구현
* `WebUtilTest` 클래스에서 `HttpRequestParse` 메소드에 대한 **단위 테스트 코드 작성**
```java
public HttpRequestParam(String method, String uri) {
        this.method = method;
        this.uri = uri;
        parseUri(uri);
    }

void parseUri(String uri) {
        String[] parsedUri = uri.split("\\.");
        this.contentType = parsedUri[parsedUri.length - 1];
        if (this.contentType.equals("html")) {
            this.path = "./src/main/resources/templates" + this.uri;
        } else {
            this.path = "./src/main/resources/static" + this.uri;
        }
    }
```

### 2. HTTP Request 내용 출력
서버로 들어오는 HTTP Request의 내용을 읽고 로거(log.debug)를 이용해 출력한다.
* `WebUtil` 클래스의 `HttpRequestParse` 메소드에서 `BufferedReader.readLine()`을 이용해 구현
* HTTP Request의 모든 내용을 출력하도록 구현했을 때 가독성 측면에서 좋지 않아 HTTP Request의 첫 번째 줄만 로거로 출력하도록 구현

### 3. Concurrent 패키지 사용
기존의 Java Thread 기반으로 작성되어 있는 코드를 Concurrent 패키지를 사용하도록 변경
* `ExecutorService`를 사용하여 최대 10개의 스레드를 가진 스레드 풀을 생성하고 관리하도록 구현

## 고민 사항
- 처음에는 일단 구현이 되도록 코드를 짜고, 이후에 Util 클래스로 분리해서 단위 테스트 코드까지 작성해보았는데 유지보수가 가능하고 가독성이 좋은 코드를 작성하기 위한 고민을 많이 해보았다. 현재는 Util 클래스의 HttpRequestParse 메소드 안에서 logger까지 사용하고 있는데, 이 부분은 밖으로 빼는 게 나아보이기도 한다... 
- HttpRequestParse 메소드에서 파싱한 HTTP Request 정보를 전달할 때 사용하기 위해 HttpRequestParam 객체를 만들어 사용했는데, 이렇게 객체 안에서 생성자로 필요한 정보를 가공해서 저장해도 괜찮을까? Util로 따로 뺼까 하다가 이건 객체 안에서 간단하게 처리할 수 있을 것 같아 이렇게 구현했는데 좋은 코드인지 고민이 된다 🧐

## 기타
- Thread와 Concurrent에 대한 이해가 아직 부족한 것 같다. 더 공부해서 Readme에 정리를 해야될 것 같다.