### PR TITLE
[Hymin2] step-1 index.html 응답

### DIFF
--- a/src/main/java/header/RequestHeader.java
+++ b/src/main/java/header/RequestHeader.java
@@ -75,4 +75,17 @@ public class RequestHeader {
             throw new RuntimeException(e);
         }
     }
+
+    @Override
+    public String toString(){
+        return String.format("\n요청 메소드: %s\n" +
+                "요청한 자원의 경로: %s\n" +
+                "프로토콜: %s\n" +
+                "서버의 주소: %s\n" +
+                "콘텐츠 타입: %s\n" +
+                "사용자의 Agent: %s\n" +
+                "연결 설정: %s\n" +
+                "언어: %s\n" +
+                "이전 경로: %s\n", method, path, protocol, Host, Accept, UserAgent, Connection, AcceptLanguage, Referer);
+    }
 }

--- a/src/main/java/header/RequestHeader.java
+++ b/src/main/java/header/RequestHeader.java
@@ -51,10 +51,10 @@ public class RequestHeader {
         RequestHeader requestHeader = of(method, path, protocol);
 
         while(!(requestLine = br.readLine()).isEmpty()){
-            st = new StringTokenizer(requestLine, ": ");
+            String[] requestLineSplit = requestLine.split(": ");
 
-            String headerName = st.nextToken().replace("-", "");
-            String headerValue = st.nextToken();
+            String headerName = requestLineSplit[0].replace("-", "");
+            String headerValue = requestLineSplit[1];
 
             setHeaderValue(requestHeader, headerName, headerValue);
         }
@@ -75,6 +75,4 @@ public class RequestHeader {
             throw new RuntimeException(e);
         }
     }
-
-
 }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -65,9 +65,9 @@ public class RequestHandler implements Runnable {
         }
     }
 
-    private void setResponse(DataOutputStream dos, String uri) throws IOException {
+    private void setResponse(DataOutputStream dos, String path) throws IOException {
         try{
-            byte[] body = Files.readAllBytes(new File(RESOURCES_URL.getPath() + uri).toPath());
+            byte[] body = Files.readAllBytes(new File(RESOURCES_URL.getPath() + path).toPath());
 
             response200Header(dos, body.length);
             responseBody(dos, body);

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -48,6 +48,17 @@ public class RequestHandler implements Runnable {
         }
     }
 
+    private void response404Header(DataOutputStream dos, int lengthOfBodyContent) {
+        try {
+            dos.writeBytes("HTTP/1.1 404 NotFound \r\n");
+            dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
+            dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
+            dos.writeBytes("\r\n");
+        } catch (IOException e) {
+            logger.error(e.getMessage());
+        }
+    }
+
     private void responseBody(DataOutputStream dos, byte[] body) {
         try {
             dos.write(body, 0, body.length);
@@ -64,6 +75,11 @@ public class RequestHandler implements Runnable {
             response200Header(dos, body.length);
             responseBody(dos, body);
         } catch (IOException e){
+            byte[] body = "404 Not Found".getBytes();
+
+            response404Header(dos, body.length);
+            responseBody(dos, body);
+
             logger.error(e.getMessage());
         }
     }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -1,21 +1,18 @@
 package webserver;
 
-import java.io.*;
-import java.net.MalformedURLException;
-import java.net.Socket;
-import java.net.URI;
-import java.net.URL;
-import java.nio.file.Files;
-import java.util.StringTokenizer;
-
+import header.RequestHeader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.net.Socket;
+import java.net.URL;
+import java.nio.file.Files;
 
 public class RequestHandler implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
     private final URL RESOURCES_URL = this.getClass().getClassLoader().getResource("./templates");
     private Socket connection;
-
 
     public RequestHandler(Socket connectionSocket) {
         this.connection = connectionSocket;
@@ -29,9 +26,9 @@ public class RequestHandler implements Runnable {
             // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
             DataOutputStream dos = new DataOutputStream(out);
 
-            String uri = parseUri(in);
+            RequestHeader requestHeader = parseHeader(in);
 
-            setResponse(dos, uri);
+            setResponse(dos, requestHeader.getPath());
         } catch (IOException e) {
             logger.error(e.getMessage());
         }
@@ -84,24 +81,12 @@ public class RequestHandler implements Runnable {
         }
     }
 
-    private String parseUri(InputStream in) throws IOException{
+    private RequestHeader parseHeader(InputStream in) throws IOException{
         BufferedReader br = new BufferedReader(new InputStreamReader(in));
+        RequestHeader requestHeader = RequestHeader.parseHeader(br);
 
-        String requestLine = br.readLine();
-        StringTokenizer st = new StringTokenizer(requestLine, " ");
+        logger.debug(requestHeader.toString());
 
-        String method = st.nextToken();
-        String uri = st.nextToken();
-        String httpVersion = st.nextToken();
-
-        logger.debug("----------------------------------------------------------------------------------------------");
-        logger.debug(requestLine);
-
-        while(!(requestLine = br.readLine()).isEmpty()){
-            logger.debug(requestLine);
-        }
-        logger.debug("----------------------------------------------------------------------------------------------");
-
-        return uri;
+        return requestHeader;
     }
 }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -1,18 +1,21 @@
 package webserver;
 
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
+import java.net.MalformedURLException;
 import java.net.Socket;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Files;
+import java.util.StringTokenizer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class RequestHandler implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
-
+    private final URL RESOURCES_URL = this.getClass().getClassLoader().getResource("./templates");
     private Socket connection;
+
 
     public RequestHandler(Socket connectionSocket) {
         this.connection = connectionSocket;
@@ -25,9 +28,10 @@ public class RequestHandler implements Runnable {
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
             // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
             DataOutputStream dos = new DataOutputStream(out);
-            byte[] body = "Hello World".getBytes();
-            response200Header(dos, body.length);
-            responseBody(dos, body);
+
+            String uri = parseUri(in);
+
+            setResponse(dos, uri);
         } catch (IOException e) {
             logger.error(e.getMessage());
         }
@@ -51,5 +55,37 @@ public class RequestHandler implements Runnable {
         } catch (IOException e) {
             logger.error(e.getMessage());
         }
+    }
+
+    private void setResponse(DataOutputStream dos, String uri) throws IOException {
+        try{
+            byte[] body = Files.readAllBytes(new File(RESOURCES_URL.getPath() + uri).toPath());
+
+            response200Header(dos, body.length);
+            responseBody(dos, body);
+        } catch (IOException e){
+            logger.error(e.getMessage());
+        }
+    }
+
+    private String parseUri(InputStream in) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(in));
+
+        String requestLine = br.readLine();
+        StringTokenizer st = new StringTokenizer(requestLine, " ");
+
+        String method = st.nextToken();
+        String uri = st.nextToken();
+        String httpVersion = st.nextToken();
+
+        logger.debug("----------------------------------------------------------------------------------------------");
+        logger.debug(requestLine);
+
+        while(!(requestLine = br.readLine()).isEmpty()){
+            logger.debug(requestLine);
+        }
+        logger.debug("----------------------------------------------------------------------------------------------");
+
+        return uri;
     }
 }

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -2,6 +2,8 @@ package webserver;
 
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,6 +20,8 @@ public class WebServer {
             port = Integer.parseInt(args[0]);
         }
 
+        ExecutorService executorService = Executors.newCachedThreadPool();
+
         // 서버소켓을 생성한다. 웹서버는 기본적으로 8080번 포트를 사용한다.
         try (ServerSocket listenSocket = new ServerSocket(port)) {
             logger.info("Web Application Server started {} port.", port);
@@ -25,8 +29,7 @@ public class WebServer {
             // 클라이언트가 연결될때까지 대기한다.
             Socket connection;
             while ((connection = listenSocket.accept()) != null) {
-                Thread thread = new Thread(new RequestHandler(connection));
-                thread.start();
+                executorService.submit(new RequestHandler(connection));
             }
         }
     }

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -31,6 +31,8 @@ public class WebServer {
             while ((connection = listenSocket.accept()) != null) {
                 executorService.submit(new RequestHandler(connection));
             }
+        } finally {
+            executorService.shutdown();
         }
     }
 }


### PR DESCRIPTION
## 구현 내용

### 정적인 html 파일 응답

```
private final URL RESOURCES_URL = this.getClass().getClassLoader().getResource("./templates");
...
byte[] body = Files.readAllBytes(new File(RESOURCES_URL.getPath() + path).toPath());
```
- 위 변수를 통해 `resources/templates`의 디렉토리 경로를 얻을 수 있었다.
- `resources/templates`의 경로와 클라이언트가 요청한 path로 거기에 속하는 resource를 반환한다.
- 만약 File을 읽었을 때 존재하지 않는 파일이면 404 Not Found를 반환하도록 하였다.

### HTTP Request 내용 출력

- RequestHeader 객체를 생성한 후 리플렉션을 통해 헤더의 key와 같은 이름을 가진 field에 해당 헤더의 값을 넣어줬다.
- 해당 객체의 toString을 구현하여 헤더의 내용을 알기 쉽게? 출력할 수 있도록 하였다.

### 구조 변경

- Concurrent 패키지 내의 `ExecutorService` 객체를 사용하여 쓰레드 풀을 생성하였다.
- `Executors.newCachedThreadPool()`을 통해 자동으로 쓰레드 풀을 관리해주는 객체를 생성하였다.

### OOP와 클린 코딩

- 함수가 최대한 한 가지의 일만 하도록 분리해주었다.

## 고민 사항

- RequestHeader의 내용을 어떻게 의미있게 가공해서 출력할지 고민했다. 각 헤더의 내용이 무엇을 뜻하는지 정도로만 출력을 했는데 이러면 그냥 전체를 출력하는 것이랑 다를바가 뭔지 잘 모르겠다.
- RequestHeader에서 요청마다 포함된 헤더의 내용이 다른데 이것을 어떻게 담아아하나 고민했다. 처음엔 If문을 도배해야하나 생각이 들었는데 팀원 중 한 분께서 리플렉션을 얘기해주셔서 적용해보기로 하였다.
- resources의 경로를 어떻게 받아와야하나 고민했었다. 처음에도 위에서 사용한 변수처럼 ~~~.getResource()를 사용했었지만 파라미터로 ""만 주었더니 ~~~/classes를 가르켰고, `..`과 같이 이전 경로로 가도록 해야하나 싶었는데 이것도 잘 되진 않았다. 하지만 파라미터에 값을 넣어주니 resources의 경로를 가져올 수 있었다.

## 기타

- Thread와 Concurrent와 Virtual Thread에 대한 글을 읽었는데 Virtual Thread에 대한 내용은 잘 모르겠다. 어렵다.