### PR TITLE
[kelly1422] step-1 index.html 응답

### DIFF
--- a/src/main/java/model/RequestDto.java
+++ b/src/main/java/model/RequestDto.java
@@ -1,0 +1,36 @@
+package model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class RequestDto {
+    private String method;
+    private String path;
+    private Map<String, String> header;
+
+    public RequestDto(String method, String path) {
+        this.method = method;
+        this.path = path;
+        this.header = new HashMap<>();
+    }
+
+    public String getMethod() {
+        return method;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void addHeader(String key, String value) {
+        this.header.put(key, value);
+    }
+
+    public String getHeader() {
+        return  "\n-------------------------------------\n" +
+                ("http method: " + this.method + "\n") +
+                ("path: " + this.path + "\n") +
+                ("Host: " + header.get("Host") + "\n") +
+                "-------------------------------------\n";
+    }
+}

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -24,7 +24,7 @@ public class RequestHandler implements Runnable {
             // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
             DataOutputStream dos = new DataOutputStream(out);
 
-            byte[] body = getFileByPath(readRquest(in));
+            byte[] body = getFileByPath(RequestParser.getPath(in));
             if (body == null) { // 해당 경로의 html 파일이 존재하지 않을 때
                 body = "Hello World".getBytes();
             }
@@ -54,20 +54,6 @@ public class RequestHandler implements Runnable {
         } catch (IOException e) {
             logger.error(e.getMessage());
         }
-    }
-
-    private String readRquest(InputStream in) throws IOException {
-        BufferedReader br = new BufferedReader(new InputStreamReader(in, "UTF-8"));
-
-        String request = br.readLine();
-        logger.debug(request);
-        String path = request.split(" ")[1];
-        while (!request.equals("")) {
-            request = br.readLine();
-            logger.debug(request);
-        }
-
-        return path;
     }
 
     private byte[] getFileByPath(String path) throws IOException {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -60,10 +60,11 @@ public class RequestHandler implements Runnable {
         BufferedReader br = new BufferedReader(new InputStreamReader(in, "UTF-8"));
 
         String request = br.readLine();
+        logger.debug(request);
         String path = request.split(" ")[1];
         while (!request.equals("")) {
             request = br.readLine();
-            logger.info(request);
+            logger.debug(request);
         }
 
         return path;

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -24,7 +24,7 @@ public class RequestHandler implements Runnable {
             // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
             DataOutputStream dos = new DataOutputStream(out);
 
-            byte[] body = getFileByPath(readRquest(new BufferedReader(new InputStreamReader(in, "UTF-8"))));
+            byte[] body = getFileByPath(readRquest(in));
             if (body == null) { // 해당 경로의 html 파일이 존재하지 않을 때
                 body = "Hello World".getBytes();
             }
@@ -56,7 +56,9 @@ public class RequestHandler implements Runnable {
         }
     }
 
-    private String readRquest(BufferedReader br) throws IOException {
+    private String readRquest(InputStream in) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(in, "UTF-8"));
+
         String request = br.readLine();
         String path = request.split(" ")[1];
         while (!request.equals("")) {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -1,10 +1,8 @@
 package webserver;
 
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.net.Socket;
+import java.nio.file.Files;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,7 +23,12 @@ public class RequestHandler implements Runnable {
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
             // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
             DataOutputStream dos = new DataOutputStream(out);
-            byte[] body = "Hello World".getBytes();
+
+            byte[] body = getFileByPath(readRquest(new BufferedReader(new InputStreamReader(in, "UTF-8"))));
+            if (body == null) { // 해당 경로의 html 파일이 존재하지 않을 때
+                body = "Hello World".getBytes();
+            }
+
             response200Header(dos, body.length);
             responseBody(dos, body);
         } catch (IOException e) {
@@ -51,5 +54,25 @@ public class RequestHandler implements Runnable {
         } catch (IOException e) {
             logger.error(e.getMessage());
         }
+    }
+
+    private String readRquest(BufferedReader br) throws IOException {
+        String request = br.readLine();
+        String path = request.split(" ")[1];
+        while (!request.equals("")) {
+            request = br.readLine();
+            logger.info(request);
+        }
+
+        return path;
+    }
+
+    private byte[] getFileByPath(String path) throws IOException {
+        File file = new File("src/main/resources/templates" + path);
+        if (file.exists()) {
+            return Files.readAllBytes(file.toPath());
+        }
+
+        return null;
     }
 }

--- a/src/main/java/webserver/RequestParser.java
+++ b/src/main/java/webserver/RequestParser.java
@@ -1,0 +1,29 @@
+package webserver;
+
+import model.RequestDto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+public class RequestParser {
+    private static final Logger logger = LoggerFactory.getLogger(RequestParser.class);
+
+    public static String getPath(InputStream in) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(in, "UTF-8"));
+
+        String line = br.readLine();
+        RequestDto requestDto = new RequestDto(line.split(" ")[0], line.split(" ")[1]);
+
+        while ((line = br.readLine()) != null && !line.equals("")) {
+            requestDto.addHeader(line.split(": ")[0], line.split(": ")[1]);
+        }
+
+        logger.debug(requestDto.getHeader());
+
+        return requestDto.getPath();
+    }
+}

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -2,6 +2,8 @@ package webserver;
 
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,13 +22,13 @@ public class WebServer {
 
         // 서버소켓을 생성한다. 웹서버는 기본적으로 8080번 포트를 사용한다.
         try (ServerSocket listenSocket = new ServerSocket(port)) {
+            Executor executor = Executors.newFixedThreadPool(10);
             logger.info("Web Application Server started {} port.", port);
 
             // 클라이언트가 연결될때까지 대기한다.
             Socket connection;
             while ((connection = listenSocket.accept()) != null) {
-                Thread thread = new Thread(new RequestHandler(connection));
-                thread.start();
+                executor.execute(new RequestHandler(connection));
             }
         }
     }


### PR DESCRIPTION
## 구현 내용
#### 1. 정적인 html 파일 응답
경로에 입력한 파일을 찾아 리턴하도록 구현

#### 2. HTTP Request 내용 출력
RequestDto 클래스를 만들고, 안에 해쉬맵 형태의 헤더 필드를 두어 헤더를 키-벨류 형식으로 저장하여, 필요한 헤더를 key 값을 통해 get 하여 사용할 수 있도록 하였다. 그 중 http 메소드와 경로와 host를 logger를 이용해 로그에 출력하도록 하였다.

#### 3. Java Thread 기반으로 작성되어 있는 코드를 Concurrent 패키지를 사용하도록 구조 변경
`Executor executor = Executors.newFixedThreadPool(10);`
`executor.execute(new RequestHandler(connection));`
10개의 스레드를 가질 수 있는 스레드풀을 생성하고 Runnable한 RequestHandler 객체를 넘겨 실행하도록 하였다.

## 고민 사항

http 요청 헤더 중 어떤 요소가 중요할지 고민했다. RequestDto 클래스를 생성하고 읽어들인 헤더의 키 값과 벨류를 저장할 map 필드를 생성해 헤더 값들을 저장하고, 필요한 헤더를 get하여 쓸 수 있게 하였다. 
하지만 해당 클래스를 처음 봤을 때, 어떤 헤더 값들이 저장되어 있는지 알 수 없다는 단점이 있다. 
이를 헤더가 각각의 필드를 가지게 변경해야 할지, 이러면 분기문으로 처리해야 하는데 이건 너무 불필요한 코드 인것 같아 고민이다.

---

Concurrent 패키지를 사용해 구조를 변경하는 과정에서 
`Executor executor = Executors.newFixedThreadPool(10);` 
위의 코드를 작성할 때, 몇 개의 스레드를 가지도록 스레드풀을 생성하면 좋을지 고민하였다. 
고민하며 스레드의 적정 개수에 대해 알아보았고, 
> 적정 스레드 개수 = CPU 코어 수 * (1 + 대기시간/작업시간)

보통 위의 공식으로 적정 스레드 수를 구하는 것을 알 수 있었다.
하지만 현재 제작하는 웹서버는 테스트할 때만 사용하기에 사용자가 여럿이 될 가능성이 거의 없어 그냥 10개로 지정해 스레드 풀을 생성하였다.

---

Runnable 객체들을 실행하기 위해 
`executor.execute() vs executor.submit() ` 중 무엇을 사용할지 고민했다.
execute은 그냥 실행만, submit은 실행 결과나 스레드에 대한 정보를 리턴받을 수 있다고 하는데, 결과는 필요 없어서 그냥 execute으로 실행하였다.
