### PR TITLE
[Yang-soeun] step-1 index.html 응답

### DIFF
--- a/src/main/java/util/HttpRequestHeader.java
+++ b/src/main/java/util/HttpRequestHeader.java
@@ -4,9 +4,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.http.HttpHeaders;
-
-public class HttpRequestHeaderHelper {
+public class HttpRequestHeader {
     private static final String END = "";
     private static final String CHARSET_NAME = "UTF-8";
     private static final String HOST = "Host:";

--- a/src/main/java/util/HttpRequestHeaderHelper.java
+++ b/src/main/java/util/HttpRequestHeaderHelper.java
@@ -1,0 +1,33 @@
+package util;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.http.HttpHeaders;
+
+public class HttpRequestHeaderHelper {
+    private static final String END = "";
+    private static final String CHARSET_NAME = "UTF-8";
+    private static final String HOST = "Host:";
+    private static final String CONNECTION = "Connection:";
+    private static final String ACCEPT = "Accept:";
+    private static final String NEW_LINE = "\n";
+
+    public static String getRequestHeader(InputStream in) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(in, CHARSET_NAME));
+        StringBuilder request = new StringBuilder();
+
+        String line = br.readLine();
+        request.append(NEW_LINE).append(line).append(NEW_LINE);
+
+        while(!line.equals(END)){
+            line = br.readLine();
+            if(line.startsWith(HOST) || line.startsWith(CONNECTION) || line.startsWith(ACCEPT)){
+                request.append(line).append(NEW_LINE);
+            }
+        }
+
+        return request.toString();
+    }
+}

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -7,16 +7,15 @@ import java.nio.file.Files;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static util.HttpRequestHeaderHelper.getRequestHeader;
+
 public class RequestHandler implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
-
-    private Socket connection;
     private static final int PATH_POS = 1;
     private static final int EXTENSION_POS = 1;
-    private static final String END = "";
     private static final String PATH_DELIMITER = " ";
     private static final String EXTENSION_DELIMITER = "/";
-
+    private Socket connection;
     public RequestHandler(Socket connectionSocket) {
         this.connection = connectionSocket;
     }
@@ -27,18 +26,15 @@ public class RequestHandler implements Runnable {
 
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
             // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
-            BufferedReader br = new BufferedReader(new InputStreamReader(in, "UTF-8"));
-            String request = br.readLine();
-            logger.debug(request);
+            String requestHeader = getRequestHeader(in);
+            logger.debug(requestHeader);
 
-            String path = request.split(PATH_DELIMITER)[PATH_POS];
+            String path = requestHeader.split(PATH_DELIMITER)[PATH_POS];
             String extension = path.split(EXTENSION_DELIMITER)[EXTENSION_POS];
-            System.out.println(extension);
 
-            while(!request.equals(END)){
-                request = br.readLine();
-                logger.debug(request);
-            }
+//            자바 스레드 돌아가는 원리
+//            concurrent 패키지에 뭐가 있는지
+//            virtual thread
 
             DataOutputStream dos = new DataOutputStream(out);
             byte[] body = Files.readAllBytes(new File(ResponseEnum.getPathName(extension) + path).toPath());

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -28,9 +28,9 @@ public class RequestHandler implements Runnable {
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
             // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
             String requestHeader = getRequestHeader(in);
-            logger.debug(requestHeader);
+            logger.debug(requestHeader); //step1-1: HTTP request 내용 출력
 
-            String path = requestHeader.split(PATH_DELIMITER)[PATH_POS];
+            String path = requestHeader.split(PATH_DELIMITER)[PATH_POS];//step1-2: request line 에서 path 분리하기
             String extension = path.split(EXTENSION_DELIMITER)[EXTENSION_POS];
 
             DataOutputStream dos = new DataOutputStream(out);

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -1,10 +1,8 @@
 package webserver;
 
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.net.Socket;
+import java.nio.file.Files;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,6 +11,11 @@ public class RequestHandler implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
 
     private Socket connection;
+    private static final int PATH_POS = 1;
+    private static final int EXTENSION_POS = 1;
+    private static final String END = "";
+    private static final String PATH_DELIMITER = " ";
+    private static final String EXTENSION_DELIMITER = "/";
 
     public RequestHandler(Socket connectionSocket) {
         this.connection = connectionSocket;
@@ -24,19 +27,32 @@ public class RequestHandler implements Runnable {
 
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
             // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
+            BufferedReader br = new BufferedReader(new InputStreamReader(in, "UTF-8"));
+            String request = br.readLine();
+            logger.debug(request);
+
+            String path = request.split(PATH_DELIMITER)[PATH_POS];
+            String extension = path.split(EXTENSION_DELIMITER)[EXTENSION_POS];
+            System.out.println(extension);
+
+            while(!request.equals(END)){
+                request = br.readLine();
+                logger.debug(request);
+            }
+
             DataOutputStream dos = new DataOutputStream(out);
-            byte[] body = "Hello World".getBytes();
-            response200Header(dos, body.length);
+            byte[] body = Files.readAllBytes(new File(ResponseEnum.getPathName(extension) + path).toPath());
+            response200Header(dos, body.length, ResponseEnum.getContentType(extension));
             responseBody(dos, body);
         } catch (IOException e) {
             logger.error(e.getMessage());
         }
     }
 
-    private void response200Header(DataOutputStream dos, int lengthOfBodyContent) {
+    private void response200Header(DataOutputStream dos, int lengthOfBodyContent, String contentType) {
         try {
             dos.writeBytes("HTTP/1.1 200 OK \r\n");
-            dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
+            dos.writeBytes("Content-Type: " + contentType + ";charset=utf-8\r\n");
             dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
             dos.writeBytes("\r\n");
         } catch (IOException e) {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -7,7 +7,8 @@ import java.nio.file.Files;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static util.HttpRequestHeaderHelper.getRequestHeader;
+import static util.HttpRequestHeader.getRequestHeader;
+
 
 public class RequestHandler implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
@@ -31,10 +32,6 @@ public class RequestHandler implements Runnable {
 
             String path = requestHeader.split(PATH_DELIMITER)[PATH_POS];
             String extension = path.split(EXTENSION_DELIMITER)[EXTENSION_POS];
-
-//            자바 스레드 돌아가는 원리
-//            concurrent 패키지에 뭐가 있는지
-//            virtual thread
 
             DataOutputStream dos = new DataOutputStream(out);
             byte[] body = Files.readAllBytes(new File(ResponseEnum.getPathName(extension) + path).toPath());

--- a/src/main/java/webserver/ResponseEnum.java
+++ b/src/main/java/webserver/ResponseEnum.java
@@ -1,0 +1,38 @@
+package webserver;
+
+public enum ResponseEnum {
+    HTML("index.html", "src/main/resources/templates", "text/html"),
+    CSS("css", "src/main/resources/static", "text/css"),
+    JS("js", "src/main/resources/static","application/javascript"),
+    FONTS("fonts", "src/main/resources/static","font/ttf");
+    private final String extension;
+    private final String pathName;
+    private final String contentType;
+
+    private static final String NONE = "없음";
+
+    ResponseEnum(String extension, String pathName, String contentType) {
+        this.extension = extension;
+        this.pathName = pathName;
+        this.contentType = contentType;
+    }
+
+    public static String getPathName(String extension) {
+        for (ResponseEnum responseEnum : values()) {
+            if (responseEnum.extension.equals(extension)) {
+                return responseEnum.pathName;
+            }
+        }
+        return NONE;
+    }
+
+    public static String getContentType(String extension) {
+        for (ResponseEnum responseEnum : values()) {
+            if (responseEnum.extension.equals(extension)) {
+                return responseEnum.contentType;
+            }
+        }
+        return NONE;
+    }
+
+}

--- a/src/main/java/webserver/ResponseEnum.java
+++ b/src/main/java/webserver/ResponseEnum.java
@@ -1,15 +1,13 @@
 package webserver;
 
 public enum ResponseEnum {
-    HTML("index.html", "src/main/resources/templates", "text/html"),
     CSS("css", "src/main/resources/static", "text/css"),
     JS("js", "src/main/resources/static","application/javascript"),
-    FONTS("fonts", "src/main/resources/static","font/ttf");
+    FONT("fonts", "src/main/resources/static","font/ttf"),
+    IMAGE("images","src/main/resources/static" , "image/");
     private final String extension;
     private final String pathName;
     private final String contentType;
-
-    private static final String NONE = "없음";
 
     ResponseEnum(String extension, String pathName, String contentType) {
         this.extension = extension;
@@ -23,7 +21,7 @@ public enum ResponseEnum {
                 return responseEnum.pathName;
             }
         }
-        return NONE;
+        return "src/main/resources/templates";
     }
 
     public static String getContentType(String extension) {
@@ -32,7 +30,7 @@ public enum ResponseEnum {
                 return responseEnum.contentType;
             }
         }
-        return NONE;
+        return "text/html";
     }
 
 }

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -2,6 +2,8 @@ package webserver;
 
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,6 +11,7 @@ import org.slf4j.LoggerFactory;
 public class WebServer {
     private static final Logger logger = LoggerFactory.getLogger(WebServer.class);
     private static final int DEFAULT_PORT = 8080;
+    private static final int N_THREADS = Runtime.getRuntime().availableProcessors();
 
     public static void main(String args[]) throws Exception {
         int port = 0;
@@ -20,14 +23,15 @@ public class WebServer {
 
         // 서버소켓을 생성한다. 웹서버는 기본적으로 8080번 포트를 사용한다.
         try (ServerSocket listenSocket = new ServerSocket(port)) {
+            ExecutorService executorService = Executors.newFixedThreadPool(N_THREADS);
             logger.info("Web Application Server started {} port.", port);
 
             // 클라이언트가 연결될때까지 대기한다.
             Socket connection;
             while ((connection = listenSocket.accept()) != null) {
-                Thread thread = new Thread(new RequestHandler(connection));
-                thread.start();
+                executorService.execute(new RequestHandler(connection));
             }
+            executorService.shutdown();
         }
     }
 }

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -22,6 +22,7 @@ public class WebServer {
         }
 
         // 서버소켓을 생성한다. 웹서버는 기본적으로 8080번 포트를 사용한다.
+        //step1-3: thread -> concurrent 패키지 사용하도록 변경
         try (ServerSocket listenSocket = new ServerSocket(port)) {
             ExecutorService executorService = Executors.newFixedThreadPool(N_THREADS);
             logger.info("Web Application Server started {} port.", port);


### PR DESCRIPTION
## 구현 내용

- [x] 서버로 들어오는 HTTP Request의 내용을 읽고 로거(log.debug)를 이용해 출력
- [x] path에 해당하는 파일 읽어 응답하기
- [x] thread -> concurrent 패키지를 사용하도록 변경

## 고민 사항
1. contentType 문제
- 처음에 request Line에서 path를 분리하여 해당하는 파일을 읽도록 구현하였으나, css 적용되지 않았다.
- 이유는 contentType text/html로 되어 있어서 적용되지 않았던 것이다.
2. contentType, pathname 지정
- 위의 문제를 해결하기 위해 request를 보고 css, html, js 등을 구별하여 맞는 contentType과  pathname을 지정해줘야 했다. 그러다 보니 if 문이 많아져서 고민이 생겼다.
- 이를 해결하기 위해서 enum을 활용해서 path에서 확장자를 이용해 해당하는 타입과, pathname을 가져오도록 코드를 수정하였다.
- 현재 생각나는 방법이 enum이여서 enum으로 했는데 다른 좋은 방법을 고민해 보고 코드를 다시 수정해야겠다.
3. Thread pool 개수
- ExecutorService executor = Executors.newFixedThreadPool();
- 위의 코드를 사용하여 thread를 concurrent 패키지를 사용하도록 변경하였는데 적절한 쓰레드 풀 개수에 대한 고민이 있었다.

## 기타
- 매직 넘버를 사용하지 않으려고 노력했다.
- Java Thread 기반으로 작성되어 있는 부분을 Concurrent 패키지를 사용하도록 변경하기 위해서 Concurrent 패키지를 공부하고 구현하느라 시간이 오래 걸렸다.
- virtual thread도 공부를 해봐야겠다.
- enum 클래스의 이름으로 어떤게 좋을지 아직도 고민이다...
