### PR TITLE
[jiaeYoon] step-1 index.html 응답

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,26 @@
 # java-was-2023
+Java Web Application Server 2023   
 
-Java Web Application Server 2023
+### 요구사항
+- GET /index.html 응답하기
+- HTTP Request 내용 출력
+- Concurrent 패키지 사용
+- 유지보수에 좋은 구조에 대해 고민하고 코드 개선하기
+  
+### 체크리스트
+- [x] http://localhost:8080/index.html 페이지에 접근 가능하다.
+- [x] Java Thread 기반으로 작성된 프로젝트를 Concurrent 패키지를 사용하도록 변경한다.
+- [x] 기능 요구사항 만족 후 리팩토링을 진행한다.
+
+### 학습 내역
+- WAS
+- HTTP
+- 스레드와 스레드 풀
+- OOP
+- 클린 코드
+
+</br>
 
 ## 프로젝트 정보 
-
 이 프로젝트는 우아한 테크코스 박재성님의 허가를 받아 https://github.com/woowacourse/jwp-was 
 를 참고하여 작성되었습니다.

--- a/src/main/java/dto/RequestDto.java
+++ b/src/main/java/dto/RequestDto.java
@@ -3,6 +3,7 @@ package dto;
 import webserver.RequestHeader;
 
 import java.util.Map;
+import java.util.LinkedHashMap;
 
 public class RequestDto {
 
@@ -25,5 +26,15 @@ public class RequestDto {
 
     public String getUrl() {
         return url;
+    }
+
+    public Map<String, String> getValues() {
+        Map<String, String> values = new LinkedHashMap<>();
+        values.put("Method", method);
+        values.put("URL", url);
+        values.put("Host", host);
+        values.put("Connection", connection);
+        values.put("Accept", accept);
+        return values;
     }
 }

--- a/src/main/java/dto/RequestDto.java
+++ b/src/main/java/dto/RequestDto.java
@@ -11,6 +11,7 @@ public class RequestDto {
     private String url;
     private String host;
     private String connection;
+    private String userAgent;
     private String accept;
 
     public void setMethodAndURL(String method, String url) {
@@ -21,6 +22,7 @@ public class RequestDto {
     public void setRequestHeaders(Map<RequestHeader, String> requestHeaders) {
         this.host = requestHeaders.get(RequestHeader.HOST);
         this.connection = requestHeaders.get(RequestHeader.CONNECTION);
+        this.userAgent = requestHeaders.get(RequestHeader.USER_AGENT);
         this.accept = requestHeaders.get(RequestHeader.ACCEPT);
     }
 
@@ -34,6 +36,7 @@ public class RequestDto {
         values.put("URL", url);
         values.put("Host", host);
         values.put("Connection", connection);
+        values.put("User-Agent", userAgent);
         values.put("Accept", accept);
         return values;
     }

--- a/src/main/java/dto/RequestDto.java
+++ b/src/main/java/dto/RequestDto.java
@@ -8,15 +8,15 @@ import java.util.LinkedHashMap;
 public class RequestDto {
 
     private String method;
-    private String url;
+    private String path;
     private String host;
     private String connection;
     private String userAgent;
     private String accept;
 
-    public void setMethodAndURL(String method, String url) {
+    public void setMethodAndPath(String method, String path) {
         this.method = method;
-        this.url = url;
+        this.path = path;
     }
 
     public void setRequestHeaders(Map<RequestHeader, String> requestHeaders) {
@@ -26,8 +26,8 @@ public class RequestDto {
         this.accept = requestHeaders.get(RequestHeader.ACCEPT);
     }
 
-    public String getUrl() {
-        return url;
+    public String getPath() {
+        return path;
     }
 
     public Map<String, String> getValues() {

--- a/src/main/java/dto/RequestDto.java
+++ b/src/main/java/dto/RequestDto.java
@@ -1,0 +1,29 @@
+package dto;
+
+import webserver.RequestHeader;
+
+import java.util.Map;
+
+public class RequestDto {
+
+    private String method;
+    private String url;
+    private String host;
+    private String connection;
+    private String accept;
+
+    public void setMethodAndURL(String method, String url) {
+        this.method = method;
+        this.url = url;
+    }
+
+    public void setRequestHeaders(Map<RequestHeader, String> requestHeaders) {
+        this.host = requestHeaders.get(RequestHeader.HOST);
+        this.connection = requestHeaders.get(RequestHeader.CONNECTION);
+        this.accept = requestHeaders.get(RequestHeader.ACCEPT);
+    }
+
+    public String getUrl() {
+        return url;
+    }
+}

--- a/src/main/java/dto/RequestDto.java
+++ b/src/main/java/dto/RequestDto.java
@@ -3,7 +3,6 @@ package dto;
 import webserver.RequestHeader;
 
 import java.util.Map;
-import java.util.LinkedHashMap;
 
 public class RequestDto {
 
@@ -28,16 +27,5 @@ public class RequestDto {
 
     public String getPath() {
         return path;
-    }
-
-    public Map<String, String> getValues() {
-        Map<String, String> values = new LinkedHashMap<>();
-        values.put("Method", method);
-        values.put("URL", url);
-        values.put("Host", host);
-        values.put("Connection", connection);
-        values.put("User-Agent", userAgent);
-        values.put("Accept", accept);
-        return values;
     }
 }

--- a/src/main/java/util/Util.java
+++ b/src/main/java/util/Util.java
@@ -1,0 +1,15 @@
+package util;
+
+public class Util {
+
+    private static final String REQUEST_LINE_DELIMITER = " ";
+    private static final String REQUEST_HEADER_DELIMITER = ": ";
+
+    public static String[] splitRequestLine(String input) {
+        return input.split(REQUEST_LINE_DELIMITER);
+    }
+
+    public static String[] splitRequestHeader(String input) {
+        return input.split(REQUEST_HEADER_DELIMITER);
+    }
+}

--- a/src/main/java/view/OutputView.java
+++ b/src/main/java/view/OutputView.java
@@ -1,0 +1,13 @@
+package view;
+
+import dto.RequestDto;
+
+import static webserver.RequestHandler.logger;
+
+public class OutputView {
+
+    public static void printRequestDto(RequestDto requestDto) {
+        requestDto.getValues()
+                .forEach((key, value) -> logger.debug("{} : {}", key, value));
+    }
+}

--- a/src/main/java/view/OutputView.java
+++ b/src/main/java/view/OutputView.java
@@ -2,12 +2,16 @@ package view;
 
 import dto.RequestDto;
 
+import java.lang.reflect.Field;
+
 import static webserver.RequestHandler.logger;
 
 public class OutputView {
 
-    public static void printRequestDto(RequestDto requestDto) {
-        requestDto.getValues()
-                .forEach((key, value) -> logger.debug("{} : {}", key, value));
+    public static void printRequestDto(RequestDto requestDto) throws IllegalAccessException {
+        for (Field field : requestDto.getClass().getDeclaredFields()){
+            field.setAccessible(true);
+            logger.debug("{} : {}", field.getName(), field.get(requestDto));
+        }
     }
 }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -25,7 +25,7 @@ public class RequestHandler implements Runnable {
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
             // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
             DataOutputStream dos = new DataOutputStream(out);
-            byte[] body = "Hello World".getBytes();
+            byte[] body = "<h1>Hello World</h1>".getBytes();
             response200Header(dos, body.length);
             responseBody(dos, body);
         } catch (IOException e) {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -36,6 +36,13 @@ public class RequestHandler implements Runnable {
             logger.debug("Request Method : {}", method);
             logger.debug("Request URL : {}", url);
 
+            while (!line.equals("")) {
+                line = br.readLine();
+                if (line.startsWith("Host") || line.startsWith("Connection") || line.startsWith("Accept:")) {
+                    logger.debug(line);
+                }
+            }
+
             DataOutputStream dos = new DataOutputStream(out);
 
             String path = "src/main/resources/";

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -34,14 +34,8 @@ public class RequestHandler implements Runnable {
 
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
             RequestDto requestDto = createRequestDto(in);
-            String url = requestDto.getUrl();
             OutputView.printRequestDto(requestDto);
-
-            DataOutputStream dos = new DataOutputStream(out);
-
-            byte[] body = Files.readAllBytes(new File(getPath(url) + url).toPath());
-            response200Header(dos, body.length);
-            responseBody(dos, body);
+            createResponse(out, requestDto.getUrl());
         } catch (IOException e) {
             logger.error(e.getMessage());
         }
@@ -67,6 +61,13 @@ public class RequestHandler implements Runnable {
         }
         requestDto.setRequestHeaders(requestHeaders);
         return requestDto;
+    }
+
+    private void createResponse(OutputStream out, String url) throws IOException {
+        DataOutputStream dos = new DataOutputStream(out);
+        byte[] body = Files.readAllBytes(new File(getPath(url) + url).toPath());
+        response200Header(dos, body.length);
+        responseBody(dos, body);
     }
 
     private static String getPath(String url) {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -4,7 +4,9 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.File;
 import java.net.Socket;
+import java.nio.file.*;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,9 +25,9 @@ public class RequestHandler implements Runnable {
                 connection.getPort());
 
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
-            // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
             DataOutputStream dos = new DataOutputStream(out);
-            byte[] body = "<h1>Hello World</h1>".getBytes();
+            String path = "src/main/resources/templates/index.html";
+            byte[] body = Files.readAllBytes(new File(path).toPath());
             response200Header(dos, body.length);
             responseBody(dos, body);
         } catch (IOException e) {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -20,6 +20,7 @@ import view.OutputView;
 
 public class RequestHandler implements Runnable {
     public static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
+    private static final String RESOURCES_PATH = "src/main/resources/";
 
     private Socket connection;
 
@@ -38,14 +39,7 @@ public class RequestHandler implements Runnable {
 
             DataOutputStream dos = new DataOutputStream(out);
 
-            String path = "src/main/resources/";
-            if (url.startsWith("/css") || url.startsWith("/fonts") || url.startsWith("/images") || url.startsWith("/js") || url.equals("/favicon.ico")) {
-                path += "static";
-            } else {
-                path += "templates";
-            }
-
-            byte[] body = Files.readAllBytes(new File(path + url).toPath());
+            byte[] body = Files.readAllBytes(new File(getPath(url) + url).toPath());
             response200Header(dos, body.length);
             responseBody(dos, body);
         } catch (IOException e) {
@@ -73,6 +67,16 @@ public class RequestHandler implements Runnable {
         }
         requestDto.setRequestHeaders(requestHeaders);
         return requestDto;
+    }
+
+    private static String getPath(String url) {
+        String path = RESOURCES_PATH;
+        if (url.startsWith("/css") || url.startsWith("/fonts") || url.startsWith("/images") || url.startsWith("/js") || url.equals("/favicon.ico")) {
+            path += "static";
+        } else {
+            path += "templates";
+        }
+        return path;
     }
 
     private void response200Header(DataOutputStream dos, int lengthOfBodyContent) {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -36,7 +36,7 @@ public class RequestHandler implements Runnable {
             RequestDto requestDto = createRequestDto(in);
             OutputView.printRequestDto(requestDto);
             createResponse(out, requestDto.getPath());
-        } catch (IOException e) {
+        } catch (IOException | IllegalAccessException e) {
             logger.error(e.getMessage());
         }
     }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -35,7 +35,7 @@ public class RequestHandler implements Runnable {
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
             RequestDto requestDto = createRequestDto(in);
             OutputView.printRequestDto(requestDto);
-            createResponse(out, requestDto.getUrl());
+            createResponse(out, requestDto.getPath());
         } catch (IOException e) {
             logger.error(e.getMessage());
         }
@@ -48,7 +48,7 @@ public class RequestHandler implements Runnable {
         String line = br.readLine();
 
         String[] requestLine = Util.splitRequestLine(line);
-        requestDto.setMethodAndURL(requestLine[0], requestLine[1]);
+        requestDto.setMethodAndPath(requestLine[0], requestLine[1]);
 
         Map<RequestHeader, String> requestHeaders = new HashMap<>();
         while (!line.equals("")) {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -16,9 +16,10 @@ import dto.RequestDto;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import util.Util;
+import view.OutputView;
 
 public class RequestHandler implements Runnable {
-    private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
+    public static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
 
     private Socket connection;
 
@@ -33,6 +34,7 @@ public class RequestHandler implements Runnable {
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
             RequestDto requestDto = createRequestDto(in);
             String url = requestDto.getUrl();
+            OutputView.printRequestDto(requestDto);
 
             DataOutputStream dos = new DataOutputStream(out);
 
@@ -63,9 +65,6 @@ public class RequestHandler implements Runnable {
         Map<RequestHeader, String> requestHeaders = new HashMap<>();
         while (!line.equals("")) {
             line = br.readLine();
-            if (line.startsWith("Host") || line.startsWith("Connection") || line.startsWith("Accept:")) {
-                logger.debug(line);
-            }
             String[] requestHeader = Util.splitRequestHeader(line);
             RequestHeader property = RequestHeader.findProperty(requestHeader[0]);
             if (property != RequestHeader.NONE) {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -4,6 +4,8 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.InputStreamReader;
+import java.io.BufferedReader;
 import java.io.File;
 import java.net.Socket;
 import java.nio.file.*;
@@ -25,9 +27,25 @@ public class RequestHandler implements Runnable {
                 connection.getPort());
 
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
+            BufferedReader br = new BufferedReader(new InputStreamReader(in));
+            String line = br.readLine();
+
+            String[] token = line.split(" ");
+            String method = token[0];
+            String url = token[1];
+            logger.debug("Request Method : {}", method);
+            logger.debug("Request URL : {}", url);
+
             DataOutputStream dos = new DataOutputStream(out);
-            String path = "src/main/resources/templates/index.html";
-            byte[] body = Files.readAllBytes(new File(path).toPath());
+
+            String path = "src/main/resources/";
+            if (url.startsWith("/css") || url.startsWith("/fonts") || url.startsWith("/images") || url.startsWith("/js") || url.equals("/favicon.ico")) {
+                path += "static";
+            } else {
+                path += "templates";
+            }
+
+            byte[] body = Files.readAllBytes(new File(path + url).toPath());
             response200Header(dos, body.length);
             responseBody(dos, body);
         } catch (IOException e) {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -65,12 +65,12 @@ public class RequestHandler implements Runnable {
 
     private void createResponse(OutputStream out, String url) throws IOException {
         DataOutputStream dos = new DataOutputStream(out);
-        byte[] body = Files.readAllBytes(new File(getPath(url) + url).toPath());
+        byte[] body = Files.readAllBytes(new File(getFilePath(url) + url).toPath());
         response200Header(dos, body.length);
         responseBody(dos, body);
     }
 
-    private static String getPath(String url) {
+    private static String getFilePath(String url) {
         String path = RESOURCES_PATH;
         if (url.startsWith("/css") || url.startsWith("/fonts") || url.startsWith("/images") || url.startsWith("/js") || url.equals("/favicon.ico")) {
             path += "static";

--- a/src/main/java/webserver/RequestHeader.java
+++ b/src/main/java/webserver/RequestHeader.java
@@ -7,6 +7,7 @@ public enum RequestHeader {
     HOST("Host"),
     CONNECTION("Connection"),
     ACCEPT("Accept"),
+    USER_AGENT("User-Agent"),
     NONE("");
 
     private final String name;

--- a/src/main/java/webserver/RequestHeader.java
+++ b/src/main/java/webserver/RequestHeader.java
@@ -1,0 +1,24 @@
+package webserver;
+
+import java.util.Arrays;
+
+public enum RequestHeader {
+
+    HOST("Host"),
+    CONNECTION("Connection"),
+    ACCEPT("Accept"),
+    NONE("");
+
+    private final String name;
+
+    RequestHeader(String name) {
+        this.name = name;
+    }
+
+    public static RequestHeader findProperty(String input) {
+        return Arrays.stream(values())
+                .filter(property -> input.equals(property.name))
+                .findFirst()
+                .orElse(NONE);
+    }
+}

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -2,6 +2,8 @@ package webserver;
 
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,10 +25,10 @@ public class WebServer {
             logger.info("Web Application Server started {} port.", port);
 
             // 클라이언트가 연결될때까지 대기한다.
+            ExecutorService executor = Executors.newFixedThreadPool(10);
             Socket connection;
             while ((connection = listenSocket.accept()) != null) {
-                Thread thread = new Thread(new RequestHandler(connection));
-                thread.start();
+                executor.submit(new RequestHandler(connection));
             }
         }
     }


### PR DESCRIPTION
## 구현 내용
**1. 정적인 html 파일 응답**
Request line에서 파싱한 URL로 파일의 path를 만들어 index.html 파일을 응답함

**2. HTTP Request 내용 출력**
유의미한 Request 데이터를 RequestDto로 저장 후 출력함
RequestDto 클래스는 HTTP Method, URL, Host, Connection, User-Agent, Accept 필드로 구성

**3. Java Thread 기반의 코드를 Concurrent 패키지를 사용하도록 변경**
Concurrent 패키지의 스레드 풀을 활용함으로서 스레드의 과도한 증폭에 따른 성능 저하를 방지함
-고정 크기의 스레드 풀 생성 : `Executors.newFixedThreadPool(10);`
-스레드 풀의 작업 큐에 작업 적재 : `executor.submit(new RequestHandler(connection));`

## 고민 사항
**1. Request 데이터 저장 객체 구성**
요청을 처리하는 데 필요한 데이터는 http method, url, message body다.
그런데 현재 RequestDto 클래스는 로그 출력용 데이터(Host, Connection, User-Agent)도 필드로 가지고 있다.
요청 처리에 필요한 데이터와 로그 출력용 데이터 dto를 분리해야 할 것 같다.

**2. Enum을 이용한 Request Header 파싱 및 RequestDto 객체 저장**
Request Header의 문자열을 읽어올 때, dto에 해당하는 속성인지를 Enum 클래스와 필터를 이용해 저장했다.
분기문을 줄이기 위한 선택이었는데 오히려 로직이 더 복잡해지지 않았나싶다. 

**3. Request 데이터 출력을 위한 dto 전달 로직**
~~Request 데이터를 출력하기 위해 RequestDto의 모든 필드를 Map에 넣어 출력 클래스에 전달하고 있다.~~
~~이 방식은 클래스에 새로운 필드가 추가 될 때마다 getValues() 함수를 수정해야 하는 단점이 있다.~~
~~좀 더 깔끔하고 간단하게 RequestDto의 모든 필드를 전달 할 수 있는 방법을 고민 중이다.~~
~~(모든 필드를 getter로 가져오는 게 최선일지)~~
-> Java Reflection을 활용해 수정([58719ff](https://github.com/softeerbootcamp-3rd/be-was/pull/60/commits/58719ff014103389397ee848d2283a80e3c13446))

**4. 유지보수에 좋은 코드**
요구사항 변화에 대비해 변경하기 쉬운 클래스를 만들고자 한다.
최대한 단일 책임 원칙을 지키도록 리팩토링했으나 추상체에 의존하는 코드를 작성하는 방법은 아직 잘 모르겠다.

## 기타
**인터페이스 타입 선언으로 느낀 다형성의 장점**
RequestDto 클래스의 getValues() 메서드에서 values 객체를 원랜 HashMap으로 선언했다.
그런데 HashMap을 사용하니 values가 key 값을 기준으로 자동 정렬돼서 원하는 출력 결과가 나오지 않았다.
이를 해결하기 위해 LinkedHashMap를 사용했는데 values 객체를 인터페이스 타입으로 선언했기 때문에 구현체가 변경되어도 메서드 사용엔 문제가 없었다.