### PR TITLE
[eekrwl] step-3 웹 서버 3단계 - 다양한 컨텐츠 타입 지원

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/controller/UserController.java
+++ b/src/main/java/controller/UserController.java
@@ -14,6 +14,6 @@ public class UserController implements Controller{
         User user = new User(paramMap.get("userId"), paramMap.get("password"), paramMap.get("name"), paramMap.get("email"));
         database.addUser(user);
 
-        return "redirect:/user/login"; //로그인 페이지로 //동작 안됨
+        return "redirect:/user/login";
     }
 }

--- a/src/main/java/webserver/HttpRequest.java
+++ b/src/main/java/webserver/HttpRequest.java
@@ -49,19 +49,17 @@ public class HttpRequest {
 
     public HttpRequest (InputStream inputStream) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(inputStream, "UTF-8"));
+        getRequestInfo(br);
+    }
 
+    private void getRequestInfo(BufferedReader br) throws IOException {
         String line = br.readLine();
         if (line != null) {
             String[] lines = line.split(" ");
             method=lines[0];
             if (lines[1].contains("?")) {
-                String paramLine = lines[1].substring(lines[1].indexOf('?')+1);
-                lines[1] = lines[1].substring(0,lines[1].indexOf('?'));
-                String[] params = paramLine.split("&");
-                for (String param : params) {
-                    String[] p = param.split("=");
-                    requestParam.put(p[0], decode(p[1]));
-                }
+                getQueryParam(lines[1]);
+                lines[1] = lines[1].substring(0,line.indexOf('?'));
             }
             url=lines[1];
             httpVersion = lines[2];
@@ -78,6 +76,16 @@ public class HttpRequest {
             }
         }
     }
+
+    private void getQueryParam(String url) {
+        String paramLine = url.substring(url.indexOf('?')+1);
+        String[] params = paramLine.split("&");
+        for (String param : params) {
+            String[] p = param.split("=");
+            requestParam.put(p[0], decode(p[1]));
+        }
+    }
+
     public void print() {
         StringBuilder sb = new StringBuilder();
         sb.append("\n= = HTTP REQUEST INFORMATION = =");

--- a/src/main/java/webserver/HttpResponse.java
+++ b/src/main/java/webserver/HttpResponse.java
@@ -18,7 +18,7 @@ public class HttpResponse {
 
     public void response200Header(int lengthOfBodyContent, String contentType) {
         try {
-            dos.writeBytes("HTTP/1.1 200 OK \r\n");
+            dos.writeBytes("HTTP/1.1 200 OK \r\n"); //이줄 필수
             dos.writeBytes("Content-Type: "+contentType+";charset=utf-8\r\n");
             dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
             dos.writeBytes("\r\n");
@@ -29,7 +29,7 @@ public class HttpResponse {
 
     public void response301RedirectHeader(String redirectUrl) {
         try {
-            dos.writeBytes("HTTP/1.1 301 Moved Permanently\r\n");
+            dos.writeBytes("HTTP/1.1 301 Moved Permanently\r\n"); //이줄 필수
             dos.writeBytes("Location: " + redirectUrl + "\r\n");
             dos.writeBytes("\r\n");
         } catch (IOException e) {

--- a/src/main/java/webserver/HttpResponse.java
+++ b/src/main/java/webserver/HttpResponse.java
@@ -16,10 +16,10 @@ public class HttpResponse {
         this.dos = dos;
     }
 
-    public void response200Header(int lengthOfBodyContent) {
+    public void response200Header(int lengthOfBodyContent, String contentType) {
         try {
             dos.writeBytes("HTTP/1.1 200 OK \r\n");
-            dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
+            dos.writeBytes("Content-Type: "+contentType+";charset=utf-8\r\n");
             dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
             dos.writeBytes("\r\n");
         } catch (IOException e) {
@@ -37,7 +37,7 @@ public class HttpResponse {
         }
     }
 
-
+//스레드 로컬
     public void responseBody(byte[] body) {
         try {
             dos.write(body, 0, body.length);

--- a/src/main/java/webserver/MimeType.java
+++ b/src/main/java/webserver/MimeType.java
@@ -1,0 +1,22 @@
+package webserver;
+
+public enum MimeType {
+    HTML("text/html"),
+    CSS("text/css"),
+    JS("text/javascript"),
+    WOFF("application/x-font"),
+    TTF("application/x-font"),
+    ICO("image/x-icon"),
+    JPEG("image/jpeg"),
+    PNG("image/png");
+
+    private final String value;
+
+    MimeType(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -2,9 +2,6 @@ package webserver;
 
 import java.io.*;
 import java.net.Socket;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -42,10 +39,7 @@ public class RequestHandler implements Runnable {
 
             HttpResponse response = new HttpResponse(dos);
 
-            String path = DEFAULT_URL;
-
-
-
+            String path;
             Controller controller = controllerMap.get(request.getUrl());
             if (controller == null) { //.html
                 if (request.getUrl().endsWith(".html")) {
@@ -58,49 +52,14 @@ public class RequestHandler implements Runnable {
                 path = controller.process(request.getRequestParam()) + ".html";
             }
 
-
-            //알아서 바디 가져오고
-
             byte[] body = null;
-            Path filePath = Paths.get(path);
-            // setBody():body setHeader(contentType
 
             if (path.startsWith("redirect:")) {
                 response.response301RedirectHeader(path.substring("redirect:".length()));
                 response.responseBody(body);
-            } else if (path.equals(DEFAULT_URL) || path.endsWith(".html")) {
-                body = Files.readAllBytes(filePath);
-                response.response200Header(body.length, "text/html");
-                response.responseBody(body);
-            } else if (path.endsWith(".css")) {
-                body = Files.readAllBytes(filePath);
-                response.response200Header(body.length, "text/css");
-                response.responseBody(body);
-            } else if (path.endsWith(".js")) {
-                body = Files.readAllBytes(filePath);
-                response.response200Header(body.length, "text/javascript");
-                response.responseBody(body);
-            } else if (path.endsWith(".woff") || path.endsWith(".ttf")) {
-                body = Files.readAllBytes(filePath);
-                response.response200Header(body.length, "application/x-font");
-                response.responseBody(body);
-            } else if(path.endsWith(".ico")) {
-                body = Files.readAllBytes(filePath);
-                response.response200Header(body.length, "image/x-icon");
-                response.responseBody(body);
-            } else if (path.endsWith(".jpg")) {
-                body = Files.readAllBytes(filePath);
-                response.response200Header(body.length, "image/jpeg");
-                response.responseBody(body);
-            } else if (path.endsWith(".png")) {
-                body = Files.readAllBytes(filePath);
-                response.response200Header(body.length, "image/png");
-                response.responseBody(body);
             } else {
-                response.respond404();
+                response.response200Header(path);
             }
-
-
 
         } catch (IOException e) {
             logger.error(e.getMessage());

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -21,6 +21,7 @@ public class RequestHandler implements Runnable {
     private Map<String, Controller> controllerMap = new HashMap<>(); //controller list
 
     private final String RESOURCES_TEMPLATES_URL = "src/main/resources/templates";
+    private final String RESOURCES_STATIC_URL = "src/main/resources/static";
 
     public RequestHandler(Socket connectionSocket) {
         this.connection = connectionSocket;
@@ -49,7 +50,7 @@ public class RequestHandler implements Runnable {
                     filePath = Paths.get(RESOURCES_TEMPLATES_URL + request.getUrl());
 
                 } else { //.js .css ...
-                    ;
+                    filePath = Paths.get(RESOURCES_STATIC_URL + request.getUrl());
                 }
             } else {
                 String path = controller.process(request.getRequestParam());
@@ -62,12 +63,38 @@ public class RequestHandler implements Runnable {
                 response.respond404();
             } else if (filePath.toString().startsWith("redirect:")) {
                 String path=filePath.toString();
-                response.response301RedirectHeader(path.substring("redirect:".length(),path.length()));
+                response.response301RedirectHeader(path.substring("redirect:".length()));
+                response.responseBody(body);
+            } else if (filePath.toString().endsWith(".html")) {
+                body = Files.readAllBytes(filePath);
+                response.response200Header(body.length, "text/html");
+                response.responseBody(body);
+            } else if (filePath.toString().endsWith(".css")) {
+                body = Files.readAllBytes(filePath);
+                response.response200Header(body.length, "text/css");
+                response.responseBody(body);
+            } else if (filePath.toString().endsWith(".js")) {
+                body = Files.readAllBytes(filePath);
+                response.response200Header(body.length, "text/javascript");
+                response.responseBody(body);
+            } else if (filePath.toString().endsWith(".woff") || filePath.toString().endsWith(".ttf")) {
+                body = Files.readAllBytes(filePath);
+                response.response200Header(body.length, "application/x-font");
+                response.responseBody(body);
+            } else if(filePath.toString().endsWith(".ico")) {
+                body = Files.readAllBytes(filePath);
+                response.response200Header(body.length, "image/x-icon");
+                response.responseBody(body);
+            } else if (filePath.toString().endsWith(".jpg")) {
+                body = Files.readAllBytes(filePath);
+                response.response200Header(body.length, "image/jpeg");
+                response.responseBody(body);
+            } else if (filePath.toString().endsWith(".png")) {
+                body = Files.readAllBytes(filePath);
+                response.response200Header(body.length, "image/png");
                 response.responseBody(body);
             } else {
-                body = Files.readAllBytes(filePath);
-                response.response200Header(body.length);
-                response.responseBody(body);
+                response.respond404();
             }
 
         } catch (IOException e) {


### PR DESCRIPTION
## 구현 내용
### 1. 다양한 컨텐츠 타입 지원
**- MimeType Enum 생성**
초기 확장자별로 else if를 계속 사용하여 코드에 중복이 많았는데, EnumType을 만들어 중복을 줄여주었습니다.

getMimeTypeFromPath 메서드에서 요청 주소의 끝에서 확장자만 잘라서 대문자로 반환해주었습니다.
src/main/resources/static/css/styles.css  -->  CSS

### 2. HttpRequest 메서드 분리

변경 전: getRequestInfo 메서드에 request에서 필요한 부분 추출하는 코드를 전부 넣었습니다.
변경 후: query parameter가 있는 경우 가져오는 메서드를 분리했습니다.




## 고민 사항
### 1. 예외처리
예외처리가 전혀되어있지 않아 존재하지 않는 주소로 요청을 보내면 하얀 빈 화면이 뜹니다.
이번주에 정해진 내용만을 구현한 것 같아 다음주에는 디테일한 부분들도 신경써보려고 합니다.

### 2. 테스트
Junit을 사용한 테스트 코드를 작성하여 실행해봐야 했는데 고민하다가 결국 하지 못했습니다.
어느 부분까지 테스트할지 고민해보고 다음주에는 테스트도 진행해보려고 합니다.

### 3. GET, POST 구분
현재 코드에서 GET, POST를 구분하지 않아 POST를 구현하게 되는 다음주를 위해 구조를 더 고민해봐야 합니다.