### PR TITLE
[Yang-soeun] step-3 다양한 컨텐츠 타입 지원

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,3 +155,32 @@ joel-costigliola.github.io](http://joel-costigliola.github.io/assertj/)
 </div>
 </details>
 
+<details>
+
+<summary> ✏ STEP 3 학습 기록 </summary>
+<div markdown="1">
+
+### MIME 타입
+- Multipurpose Internet Mail Extensions
+- 미디어 타입이란 문서, 파일 또는 바이트 집합의 성격과 형식을 나타낸다.
+- 간단히 말하면 파일 변환을 의미한다.
+- 현재는 웹을 통해 여러 파일을 전달하는데 사용되고 있지만 이 용어가 생길 땐 이메일과 함께 동봉할 파일을 텍스트 문자로 전환해서 이메일 시스템을 통해 전달하기 위해 개발되어 Internet Mail Extensions라고 불리기 시작했다고 한다.
+
+### MIME 사용이유
+- 예전에는 텍스트파일을 주고 받는데 ASCII 코드로 공통된 표준에 따르기면 하면 되었으나, 네트워크를 통해 ASCII가 아닌 Binary 파일을 보내는 경우가 생기게 되었다. 음악파일, 비디오파일, 워드파일 등등 ASCII만으로 전송이 불가하기 때문에 기존시스템에서 문제없이 전달하기 위해 텍스트변환이 필요했다.
+TCP/IP 네트워크에서 이메일교환 시 표준으로 RFC822(기본 이메일메시지 형식 정의)이메일 메시지 형식이 사용되는데 이 형식은 ASCII코드를 사용하기 때문에 간단한 메시지를 전송할 경우에는 유용하지만, 다른 통신형태까지 모두 지원하기에는 유연성이 부족하다.
+따라서, 이러한 다른 통신형태의 다양한 메시지를 지원하기 위해서 MIME표준이 개발된 것이다.
+
+### 웹 개발에 자주 쓰이는 타입 
+
+|type|discription|
+|------|---|
+|application/octet-stream|바이너리 파일의 기본|
+|text/plain|텍스트, unknown textual file이어도 브러우저는 display|
+|text/css|웹 페이지 스타일링을 하는 css 파일은 반드시 text/css 타입으로 보내야 함|
+|text/html|HTML 파일은 반드시 이 타입으로 보내져야 햠|
+|text/javascript|다른 타입으로 보내게 되면 로드나 실행되지 않음|
+
+</div>
+</details>
+

--- a/src/main/java/constant/HttpRequestConstant.java
+++ b/src/main/java/constant/HttpRequestConstant.java
@@ -14,6 +14,4 @@ public class HttpRequestConstant {
     public static final int HTTP_METHOD_POS = 0;
     public static final int PATH_POS = 1;
     public static final String PATH_DELIMITER = " ";
-    public static final int EXTENSION_POS = 1;
-    public static final String EXTENSION_DELIMITER = "/";
 }

--- a/src/main/java/constant/HttpRequestConstant.java
+++ b/src/main/java/constant/HttpRequestConstant.java
@@ -14,4 +14,6 @@ public class HttpRequestConstant {
     public static final int HTTP_METHOD_POS = 0;
     public static final int PATH_POS = 1;
     public static final String PATH_DELIMITER = " ";
+    public static final int EXTENSION_POS = 1;
+    public static final String EXTENSION_DELIMITER = "/";
 }

--- a/src/main/java/controller/ResourceController.java
+++ b/src/main/java/controller/ResourceController.java
@@ -1,0 +1,20 @@
+package controller;
+
+import model.HttpRequest;
+import model.HttpResponse;
+
+import java.io.IOException;
+
+import static webserver.HttpStatus.INTERNAL_SERVER_ERROR;
+import static webserver.HttpStatus.OK;
+
+public class ResourceController {
+    public static HttpResponse serveStaticFile(HttpRequest httpRequest) {
+        try {
+            return HttpResponse.response200(OK, httpRequest.getExtension(), httpRequest.getPath());
+        } catch (IOException e){
+            return HttpResponse.errorResponse(INTERNAL_SERVER_ERROR, e.getMessage());
+        }
+    }
+
+}

--- a/src/main/java/controller/UserController.java
+++ b/src/main/java/controller/UserController.java
@@ -13,9 +13,8 @@ public class UserController {
         try{
             UserDto userDto = UserDto.from(httpRequest.getUri().getQuery());
             UserService.signUp(userDto);
-            System.out.println(HttpResponse.redirect(FOUND, "/index.html").toString());
             return HttpResponse.redirect(FOUND, "/index.html");
-        }catch (IllegalArgumentException e){
+        }catch (IllegalArgumentException | NullPointerException e){
             return HttpResponse.errorResponse(BAD_REQUEST, e.getMessage());
         }
     }

--- a/src/main/java/dto/request/UserDto.java
+++ b/src/main/java/dto/request/UserDto.java
@@ -22,7 +22,6 @@ public class UserDto {
     }
 
     public static UserDto from(String query){
-        System.out.println(query);
         Map<String, String> parameters = Arrays.stream(query.split("&"))
                 .map(param -> param.split("="))
                 .filter(pair -> pair.length > 1)

--- a/src/main/java/model/HttpRequest.java
+++ b/src/main/java/model/HttpRequest.java
@@ -21,6 +21,10 @@ public class HttpRequest {
 
     private static final int KEY_INDEX = 0;
     private static final int VALUE_INDEX = 1;
+    public static final int EXTENSION_POS = 1;
+    public static final String SLASH_DELIMITER = "/";
+    public static final String DOT_DELIMITER = "\\.";
+
     public HttpRequest(String method, URI uri, String host, String connection, String accept) {
         this.method = Objects.requireNonNull(method);
         this.uri = Objects.requireNonNull(uri);
@@ -47,6 +51,15 @@ public class HttpRequest {
 
     public String getMethod() {
         return method;
+    }
+
+    public String getPath() {
+        return uri.getPath();
+    }
+
+    public String getExtension() {
+        String[] split = getPath().split(SLASH_DELIMITER)[EXTENSION_POS].split(DOT_DELIMITER);
+        return split.length > 1 ? split[1] : split[0];
     }
 
     private static Map<String, String> getRequestHeader(InputStream in) throws IOException {
@@ -83,5 +96,4 @@ public class HttpRequest {
                 "connection='" + connection + "\n" +
                 "accept='" + accept + " }";
     }
-
 }

--- a/src/main/java/model/HttpResponse.java
+++ b/src/main/java/model/HttpResponse.java
@@ -21,9 +21,6 @@ public class HttpResponse {
     private static final String LOCATION = "Location: ";
     private static final byte[] NO_BODY = "".getBytes();
     private static final String CRLF = "\r\n";
-    public static final int EXTENSION_POS = 1;
-    public static final String SLASH_DELIMITER = "/";
-    public static final String DOT_DELIMITER = "\\.";
 
     private final HttpStatus httpStatus;
     private Map<String, String> header;
@@ -76,11 +73,7 @@ public class HttpResponse {
         return new HttpResponse(httpStatus, header, errorMessageBytes);
     }
 
-    public static HttpResponse response200(HttpRequest httpRequest, HttpStatus httpStatus) throws IOException {
-        String path = httpRequest.getUri().getPath();
-        String[] split = path.split(SLASH_DELIMITER)[EXTENSION_POS].split(DOT_DELIMITER);
-        String extension = split.length > 1 ? split[1] : split[0];
-
+    public static HttpResponse response200(HttpStatus httpStatus, String extension, String path) throws IOException {
         byte[] body = Files.readAllBytes(new File(ResponseEnum.getPathName(extension) + path).toPath());
 
         Map<String, String> header = new HashMap<>();

--- a/src/main/java/model/HttpResponse.java
+++ b/src/main/java/model/HttpResponse.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -22,6 +21,9 @@ public class HttpResponse {
     private static final String LOCATION = "Location: ";
     private static final byte[] NO_BODY = "".getBytes();
     private static final String CRLF = "\r\n";
+    public static final int EXTENSION_POS = 1;
+    public static final String SLASH_DELIMITER = "/";
+    public static final String DOT_DELIMITER = "\\.";
 
     private final HttpStatus httpStatus;
     private Map<String, String> header;
@@ -76,7 +78,9 @@ public class HttpResponse {
 
     public static HttpResponse response200(HttpRequest httpRequest, HttpStatus httpStatus) throws IOException {
         String path = httpRequest.getUri().getPath();
-        String extension = path.split(EXTENSION_DELIMITER)[EXTENSION_POS];
+        String[] split = path.split(SLASH_DELIMITER)[EXTENSION_POS].split(DOT_DELIMITER);
+        String extension = split.length > 1 ? split[1] : split[0];
+
         byte[] body = Files.readAllBytes(new File(ResponseEnum.getPathName(extension) + path).toPath());
 
         Map<String, String> header = new HashMap<>();

--- a/src/main/java/model/HttpResponse.java
+++ b/src/main/java/model/HttpResponse.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -22,6 +21,9 @@ public class HttpResponse {
     private static final String LOCATION = "Location: ";
     private static final byte[] NO_BODY = "".getBytes();
     private static final String CRLF = "\r\n";
+    public static final int EXTENSION_POS = 1;
+    public static final String SLASH_DELIMITER = "/";
+    public static final String DOT_DELIMITER = "\\.";
 
     private final HttpStatus httpStatus;
     private Map<String, String> header;
@@ -76,7 +78,10 @@ public class HttpResponse {
 
     public static HttpResponse response200(HttpRequest httpRequest, HttpStatus httpStatus) throws IOException {
         String path = httpRequest.getUri().getPath();
-        String extension = path.split(EXTENSION_DELIMITER)[EXTENSION_POS];
+
+        String[] split = path.split(SLASH_DELIMITER)[EXTENSION_POS].split(DOT_DELIMITER);
+        String extension = split.length > 1 ? split[1] : split[0];
+
         byte[] body = Files.readAllBytes(new File(ResponseEnum.getPathName(extension) + path).toPath());
 
         Map<String, String> header = new HashMap<>();
@@ -93,5 +98,4 @@ public class HttpResponse {
                 ", body=" + new String(body, StandardCharsets.UTF_8) +
                 '}';
     }
-
 }

--- a/src/main/java/model/HttpResponse.java
+++ b/src/main/java/model/HttpResponse.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -21,9 +22,6 @@ public class HttpResponse {
     private static final String LOCATION = "Location: ";
     private static final byte[] NO_BODY = "".getBytes();
     private static final String CRLF = "\r\n";
-    public static final int EXTENSION_POS = 1;
-    public static final String SLASH_DELIMITER = "/";
-    public static final String DOT_DELIMITER = "\\.";
 
     private final HttpStatus httpStatus;
     private Map<String, String> header;
@@ -78,10 +76,7 @@ public class HttpResponse {
 
     public static HttpResponse response200(HttpRequest httpRequest, HttpStatus httpStatus) throws IOException {
         String path = httpRequest.getUri().getPath();
-
-        String[] split = path.split(SLASH_DELIMITER)[EXTENSION_POS].split(DOT_DELIMITER);
-        String extension = split.length > 1 ? split[1] : split[0];
-
+        String extension = path.split(EXTENSION_DELIMITER)[EXTENSION_POS];
         byte[] body = Files.readAllBytes(new File(ResponseEnum.getPathName(extension) + path).toPath());
 
         Map<String, String> header = new HashMap<>();
@@ -98,4 +93,5 @@ public class HttpResponse {
                 ", body=" + new String(body, StandardCharsets.UTF_8) +
                 '}';
     }
+
 }

--- a/src/main/java/util/URLMapper.java
+++ b/src/main/java/util/URLMapper.java
@@ -1,5 +1,6 @@
 package util;
 
+import controller.ResourceController;
 import controller.UserController;
 import model.HttpRequest;
 import model.HttpResponse;
@@ -16,8 +17,10 @@ public class URLMapper {
         URL_MAPPING.put("GET /user/create", UserController::createUser);
     }
 
+    //찾으면 찾은 컨트롤러 반환, 못 찾으면 ResourceController 반환
     public static Function<HttpRequest, HttpResponse> getController(HttpRequest httpRequest) {
-        return URL_MAPPING.get(httpRequest.getMethod() + " " + httpRequest.getUri().getPath());
-    }
+        String findController = httpRequest.getMethod() + " " + httpRequest.getUri().getPath();
 
+        return URL_MAPPING.getOrDefault(findController, ResourceController::serveStaticFile);
+    }
 }

--- a/src/main/java/webserver/HttpStatus.java
+++ b/src/main/java/webserver/HttpStatus.java
@@ -3,7 +3,8 @@ package webserver;
 public enum HttpStatus {
     OK("200", "OK"),
     FOUND("302", "Found"),
-    BAD_REQUEST("400", "Bad Request");
+    BAD_REQUEST("400", "Bad Request"),
+    INTERNAL_SERVER_ERROR("500", "Internal Server Error");
     private String code;
     private String status;
 

--- a/src/main/java/webserver/HttpStatus.java
+++ b/src/main/java/webserver/HttpStatus.java
@@ -2,14 +2,8 @@ package webserver;
 
 public enum HttpStatus {
     OK("200", "OK"),
-    CREATED("201", "Created"),
-    NO_CONTENT("204", "No Content"),
     FOUND("302", "Found"),
-    BAD_REQUEST("400", "Bad Request"),
-    FORBIDDEN("403", "Forbidden"),
-    NOT_FOUND("404", "Not Found"),
-    INTERNAL_SERVER_ERROR("500", "Internal Server Error");
-
+    BAD_REQUEST("400", "Bad Request");
     private String code;
     private String status;
 

--- a/src/main/java/webserver/HttpStatus.java
+++ b/src/main/java/webserver/HttpStatus.java
@@ -2,8 +2,13 @@ package webserver;
 
 public enum HttpStatus {
     OK("200", "OK"),
+    CREATED("201", "Created"),
+    NO_CONTENT("204", "No Content"),
     FOUND("302", "Found"),
-    BAD_REQUEST("400", "Bad Request");
+    BAD_REQUEST("400", "Bad Request"),
+    FORBIDDEN("403", "Forbidden"),
+    NOT_FOUND("404", "Not Found"),
+    INTERNAL_SERVER_ERROR("500", "Internal Server Error");
 
     private String code;
     private String status;

--- a/src/main/java/webserver/HttpStatus.java
+++ b/src/main/java/webserver/HttpStatus.java
@@ -2,13 +2,8 @@ package webserver;
 
 public enum HttpStatus {
     OK("200", "OK"),
-    CREATED("201", "Created"),
-    NO_CONTENT("204", "No Content"),
     FOUND("302", "Found"),
-    BAD_REQUEST("400", "Bad Request"),
-    FORBIDDEN("403", "Forbidden"),
-    NOT_FOUND("404", "Not Found"),
-    INTERNAL_SERVER_ERROR("500", "Internal Server Error");
+    BAD_REQUEST("400", "Bad Request");
 
     private String code;
     private String status;

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -28,7 +28,7 @@ public class RequestHandler implements Runnable {
             Function<HttpRequest, HttpResponse> controller = URLMapper.getController(httpRequest);
 
             if(controller == null){
-                HttpResponse httpResponse = HttpResponse.response200(httpRequest, OK);
+                HttpResponse httpResponse = HttpResponse.response200(OK, httpRequest.getPath(), httpRequest.getExtension());
                 httpResponse.send(out);
                 return;
             }
@@ -40,5 +40,4 @@ public class RequestHandler implements Runnable {
             logger.error(e.getMessage());
         }
     }
-
 }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -24,7 +24,6 @@ public class RequestHandler implements Runnable {
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
             // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
             HttpRequest httpRequest = HttpRequest.from(in);
-            System.out.println(httpRequest.toString());
             Function<HttpRequest, HttpResponse> controller = URLMapper.getController(httpRequest);
 
             if(controller == null){

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -9,7 +9,6 @@ import model.HttpResponse;
 import util.URLMapper;
 
 import static constant.HttpRequestConstant.*;
-import static webserver.HttpStatus.OK;
 
 public class RequestHandler implements Runnable {
     private Socket connection;
@@ -25,13 +24,8 @@ public class RequestHandler implements Runnable {
             // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
             HttpRequest httpRequest = HttpRequest.from(in);
             logger.debug(httpRequest.toString());
-            Function<HttpRequest, HttpResponse> controller = URLMapper.getController(httpRequest);
 
-            if(controller == null){
-                HttpResponse httpResponse = HttpResponse.response200(OK, httpRequest.getExtension(), httpRequest.getPath());
-                httpResponse.send(out);
-                return;
-            }
+            Function<HttpRequest, HttpResponse> controller = URLMapper.getController(httpRequest);
 
             HttpResponse httpResponse = controller.apply(httpRequest);
             httpResponse.send(out);

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -24,7 +24,7 @@ public class RequestHandler implements Runnable {
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
             // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
             HttpRequest httpRequest = HttpRequest.from(in);
-            System.out.println(httpRequest.toString());
+            logger.debug(httpRequest.toString());
             Function<HttpRequest, HttpResponse> controller = URLMapper.getController(httpRequest);
 
             if(controller == null){

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -28,7 +28,7 @@ public class RequestHandler implements Runnable {
             Function<HttpRequest, HttpResponse> controller = URLMapper.getController(httpRequest);
 
             if(controller == null){
-                HttpResponse httpResponse = HttpResponse.response200(OK, httpRequest.getPath(), httpRequest.getExtension());
+                HttpResponse httpResponse = HttpResponse.response200(OK, httpRequest.getExtension(), httpRequest.getPath());
                 httpResponse.send(out);
                 return;
             }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -24,6 +24,7 @@ public class RequestHandler implements Runnable {
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
             // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
             HttpRequest httpRequest = HttpRequest.from(in);
+            System.out.println(httpRequest.toString());
             Function<HttpRequest, HttpResponse> controller = URLMapper.getController(httpRequest);
 
             if(controller == null){

--- a/src/main/java/webserver/ResponseEnum.java
+++ b/src/main/java/webserver/ResponseEnum.java
@@ -5,7 +5,8 @@ public enum ResponseEnum {
     CSS("css", "src/main/resources/static", "text/css"),
     JS("js", "src/main/resources/static","application/javascript"),
     FONT("fonts", "src/main/resources/static","font/ttf"),
-    IMAGE("images","src/main/resources/static" , "image/*");
+    IMAGE("images","src/main/resources/static" , "image/*"),
+    ICON("ico", "src/main/resources/static", "image/x-icon");
     private final String extension;
     private final String pathName;
     private final String contentType;

--- a/src/main/java/webserver/ResponseEnum.java
+++ b/src/main/java/webserver/ResponseEnum.java
@@ -5,8 +5,7 @@ public enum ResponseEnum {
     CSS("css", "src/main/resources/static", "text/css"),
     JS("js", "src/main/resources/static","application/javascript"),
     FONT("fonts", "src/main/resources/static","font/ttf"),
-    IMAGE("images","src/main/resources/static" , "image/*"),
-    ICON("ico", "src/main/resources/static", "image/x-icon");
+    IMAGE("images","src/main/resources/static" , "image/*");
     private final String extension;
     private final String pathName;
     private final String contentType;

--- a/src/test/java/controller/UserControllerTest.java
+++ b/src/test/java/controller/UserControllerTest.java
@@ -26,7 +26,7 @@ class UserControllerTest {
     @Test
     void userController() throws IOException {
         //given
-        HttpRequest mockRequest = createMockRequest("GET /user/create?userId=user1&password=1234&name=test&email=test%40naver.com HTTP/1.1");
+        HttpRequest mockRequest = createMockRequest("user1", "1234", "name", "soeun@naver.com");
 
         //when
         HttpResponse httpResponse = UserController.createUser(mockRequest);
@@ -40,7 +40,7 @@ class UserControllerTest {
     @Test
     void userControllerSameUserId() throws IOException {
         //given
-        HttpRequest mockRequest = createMockRequest("GET /user/create?userId=userId&password=1234&name=name&email=test%40naver.com HTTP/1.1");
+        HttpRequest mockRequest = createMockRequest("userId", "1234", "name", "soeun@naver.com");
 
         //when
         HttpResponse httpResponse = UserController.createUser(mockRequest);
@@ -50,8 +50,23 @@ class UserControllerTest {
         assertThat(responseToString).isEqualTo("HttpResponse{httpStatus=BAD_REQUEST, body=이미 존재하는 아이디입니다.}");
     }
 
-    private static HttpRequest createMockRequest(String requestLine) throws IOException {
-        String mockRequest = requestLine + "\n" +
+    @DisplayName("회원 가입 시 아이디가 없는 경우 ErrorResponse를 보낸다.")
+    @Test
+    void userControllerSameUserIdWithoutUserId() throws IOException {
+        //given
+        HttpRequest mockRequest = createMockRequest("", "1234", "name", "soeun@naver.com");
+
+        //when
+        HttpResponse httpResponse = UserController.createUser(mockRequest);
+
+        //then
+        String responseToString = httpResponse.toString();
+        assertThat(responseToString).isEqualTo("HttpResponse{httpStatus=BAD_REQUEST, body=userId는 필수입니다.}");
+    }
+
+    private static HttpRequest createMockRequest(String userId, String password, String name, String email) throws IOException {
+        String mockRequest = "GET /user/create?userId=" + userId + "&password=" + password +
+                "&name=" + name + "&email=" + email + " HTTP/1.1" + "\n" +
                 "Host: localhost:8080\n" +
                 "Connection: keep-alive\n" +
                 "Accept: */*\n" +
@@ -62,5 +77,4 @@ class UserControllerTest {
 
         return HttpRequest.from(in);
     }
-
 }

--- a/src/test/java/dto/request/UserDtoTest.java
+++ b/src/test/java/dto/request/UserDtoTest.java
@@ -23,16 +23,4 @@ class UserDtoTest {
                 .contains("user1", "1234", "test", "test@naver.com");
     }
 
-    @DisplayName("하나라도 필드가 없는 경우 예외가 발생한다.")
-    @Test
-    void userDtoFromWithNoEmail(){
-        //given
-        String query = "userId=user1&password=1234&name=test&email=";
-
-        //when //then
-        assertThatThrownBy(() -> UserDto.from(query))
-                .isInstanceOf(NullPointerException.class)
-                .hasMessage("email은 필수입니다.");
-    }
-
 }

--- a/src/test/java/service/UserServiceTest.java
+++ b/src/test/java/service/UserServiceTest.java
@@ -34,6 +34,7 @@ class UserServiceTest {
         assertThat(user)
                 .extracting("userId", "password", "name", "email")
                 .contains("user1", "1234", "test", "test@naver.com");
+
     }
 
     @DisplayName("이미 존재하는 아이디인 경우 예외가 발생한다.")

--- a/src/test/java/webserver/ResponseEnumTest.java
+++ b/src/test/java/webserver/ResponseEnumTest.java
@@ -1,0 +1,37 @@
+package webserver;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+class ResponseEnumTest {
+
+    @DisplayName("확장자로 path를 찾는다.")
+    @Test
+    void getPathName(){
+        //given
+        String extension = "ico";
+
+        //when
+        String pathName = ResponseEnum.getPathName(extension);
+
+        //then
+        assertThat(pathName).isEqualTo("src/main/resources/static");
+    }
+
+    @DisplayName("확장자로 response의 contentType을 찾는다.")
+    @Test
+    void getContentType(){
+        //given
+        String extension = "ico";
+
+        //when
+        String contentType = ResponseEnum.getContentType(extension);
+
+        //then
+        assertThat(contentType).isEqualTo("image/x-icon");
+    }
+
+}


### PR DESCRIPTION
## 구현 내용
1. ico 타입을 지원하도록 구현
2. resourceController를 구현하여 찾는 컨트롤러가 없는 경우 resourceController를 반환하도록 구현하여 정적인 요청을 처리할 수 있도록 기존 로직을 수정

```
public class URLMapper {
    public static final Map<String, Function<HttpRequest, HttpResponse>> URL_MAPPING = new HashMap<>();

    static {
        URL_MAPPING.put("GET /user/create", UserController::createUser);
    }

    //찾으면 찾은 컨트롤러 반환, 못 찾으면 ResourceController 반환
    public static Function<HttpRequest, HttpResponse> getController(HttpRequest httpRequest) {
        String findController = httpRequest.getMethod() + " " + httpRequest.getUri().getPath();

        return URL_MAPPING.getOrDefault(findController, ResourceController::serveStaticFile);
    }
}
```

## 고민 사항
1. send()메소드 위치
- 현재 코드에서는 send() 메소드의 위치를 HttpResponse 클래스 안에 위치하도록 구현하였는데 HttpResponse 클래스의 역할은 응답을 만드는 역할만 한다고 생각을 한다. 그래서 send() 메소드는 분리되어야 한다고 생각을 하고 있다. 하지만 send() 메소드를 분리할 경우 현재 send() 메소드 안에서 HttpResponse의 필드를 많이 이용하고 있기 때문에 HttpResponse 클래스의 Getter를 많이 열어줘야 하는 상황이 발생하는 것 같아서 어떻게 하면 잘 분리할 수 있을지에 대한 구조에 대한 고민을 하고 있다.

2. Content-Type 처리
- 현재는 확장자에 따른 contentType을 직접 enum에 넣어서 관리를 하고 있지만 직접 넣어서 하는것 보다 요청 헤더의 Accept를 사용하여 처리하는 방법에 대해서 생각중이다.

## 기타
step-1에서 다양한 컨텐츠 타입 부분까지 해야하는 줄 알고 처리를 했었어서 ico타입만 추가를 했다.
이번 미션을 하면서 MIME타입에 대해서도 공부를 했다. 
