### PR TITLE
[Tin9oo] step-3 다양한 컨텐츠 타입 지원

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,3 +263,97 @@ Content-Type: text/html; charset=iso-8859-1
 
 ---
 
+<details>
+    <summary><b>Step 3 - 다양한 컨텐츠 타입 지원</b></summary>
+
+### 1. 학습 목표
+> - HTTP Response에 대해 학습한다.
+> - MIME 타입에 대해 이해하고 이를 적용할 수 있다.
+
+### 2. 기능 요구사항
+- 구현
+> - 지금까지의 코드는 stylesheet와 파비콘을 지원하지 못한다. 다양한 컨텐츠 타입을 지원하도록 개한다.
+>   - html
+>   - css
+>   - js
+>   - ico
+>   - png
+>   - jpg
+
+- 테스트
+>  - static 폴더의 정적 컨텐츠 요청이 정상적으로 처리되는지 확인
+
+### 3. 학습 내용
+#### 1. MIME Type
+- MIME 타입이란?
+> - 웹에서 파일의 형식을 지정하기 위한 식별자
+> - HTTP에서는 리소스의 종류를 나타냄
+> - 주로 확장자를 기반으로 결정
+
+- MIME 타입의 구조
+> - 슬래시(`/`)로 구분된 `type`과 `subtype` 두 부분으로 구성된다
+>   - `type/subtype`
+>   - 반드시 둘 다 있어야한다
+> 
+> 
+> - `type`은 video나 text같이 데이터 타입이 속하는 일반 카테고리를 나눈다
+> 
+> 
+> - `subtype`은 MIME 타입이 나타내는 정확한 데이터 종류를 식별한다
+>   - `text`가 `type`이라면 `plain`(평문), `html`(html 소스코드)가 있다
+> 
+> 
+> - 세부 정보를 제공하기 위해 선택적 매개변수를 추가할 수 있다
+>   - `type/subtype;parameter=value`
+>   - `text/plain;charset=UTF-8`
+> 
+> 
+> - MIME 타입은 대소문자를 구분하지 않지만 소문자를 사용한다
+>   - 매개변수는 대소문자를 구분한다
+
+- Content-Type
+> - `html`: `text/html`
+> - `css`: `text/css`
+> - `js`: `application/javascript`
+> - `ico`: `image/ico`
+> - `png`: `image/png`
+> - `jpg`: `image/jpg`
+
+#### 2. Concurrent
+- 공유자원 접근 문제
+> - 여러 스레드가 공유 자원에 동시 접근하며, 데이터 불일치나 예측할 수 없는 동작을 수행함
+> - 이를 해결하기 위해 개발자는 명시적 동기화 기법을 사용해야하나, 이는 복잡하고 오류 발생 가능성이 높음
+
+- Concurrent 패키지
+> - Java 5 부터 도입
+> - 여러 작업을 동시에 할 수 있도록 함
+> - 동시성 문제를 해결하기 위한 패키지
+
+- Concurrent 패키지 사용
+> - Executors
+>   - 고수준 Concurrency 프로그래밍
+>   - Thread 생성/관리
+>   - 작업 처리 및 실행
+>   - Executor : 스레드 생성
+>   - ExecutorService : Executor 상속받은 인터페이스, 실행 종료에 관여
+> - Concurrent Collections : 동시성을지원하는 다양한 컬렉션 클래스 제공
+
+
+### 4. Trouble Shooting
+- 스타일 시트 인식 오류
+> - 스타일 시트 파일을 브라우저에 보내도 반영이 되지 않음
+> - MIME 타입을 참고하여 확장자에 따른 Content-Type을 응답에 담아 보내야함
+> - 각 확장자에 맞는 Content-Type을 매핑하여 응답에 담아 보내어 해결함.
+
+- 라우팅 코드의 가독성과 유지보수 개선
+> - 기존에는 모든 확장자에 대한 리소스 경로를 조건문으로 매핑해야함
+> - 가독성도 좋지 않다고 판단함
+> - 해시맵에 각 진입 경로에 따른 값을 매핑하여 클래스로 격리
+>   - 진입 가능한 경우에 대한 처리를 책입 분리하여 컨트롤러가 하는 일에 집중하여 변경의 사유를 하나만 가지게 만듬
+
+### 5. 추가 학습 내용
+[좋은 회고란?](https://velog.io/@tin9oo/%EC%A2%8B%EC%9D%80-%ED%9A%8C%EA%B3%A0%EB%9E%80)
+
+---
+
+</details>

--- a/src/main/java/controller/RequestDataController.java
+++ b/src/main/java/controller/RequestDataController.java
@@ -31,11 +31,9 @@ public class RequestDataController {
         try {
             File file;
 
-            if(extension.equals("html")) {
-                file = new File(ResourceLoader.url + "/templates" + url);
-            } else {
-                file = new File(ResourceLoader.url + "/static" + url);
-            }
+            String directory = ResourcePathMapping.getDirectory(extension);
+
+            file = new File(ResourceLoader.url + directory + url);
 
             String fileOrApi = getResourceType(url); // URL이 FILE을 나타내는지 API를 나타내는지 문자열로 반환
 

--- a/src/main/java/controller/RequestDataController.java
+++ b/src/main/java/controller/RequestDataController.java
@@ -26,8 +26,16 @@ public class RequestDataController {
     public static String routeRequest(RequestData requestData) {
         String url = requestData.getRequestContent();
 
+        String extension = getFileExtension(url);
+
         try {
-            File file = new File(ResourceLoader.url + "/templates" + url);
+            File file;
+
+            if(extension.equals("html")) {
+                file = new File(ResourceLoader.url + "/templates" + url);
+            } else {
+                file = new File(ResourceLoader.url + "/static" + url);
+            }
 
             String fileOrApi = getResourceType(url); // URL이 FILE을 나타내는지 API를 나타내는지 문자열로 반환
 

--- a/src/main/java/controller/ResourcePathMapping.java
+++ b/src/main/java/controller/ResourcePathMapping.java
@@ -1,0 +1,40 @@
+package controller;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ResourcePathMapping {
+
+    private static Map<String, String> extensionToDirectoryPath = new HashMap<>();
+    private static Map<String, String> extensionToContentType = new HashMap<>();
+
+    static {
+        extensionToDirectoryPath.put("html", "/templates");
+        extensionToDirectoryPath.put("css", "/static");
+        extensionToDirectoryPath.put("js", "/static");
+        extensionToDirectoryPath.put("ico", "/static");
+        extensionToDirectoryPath.put("png", "/static");
+        extensionToDirectoryPath.put("jpg", "/static");
+        extensionToDirectoryPath.put("woff", "/static");
+        extensionToDirectoryPath.put("ttf", "/static");
+    }
+
+    static {
+        extensionToContentType.put("html", "text/html");
+        extensionToContentType.put("css", "text/css");
+        extensionToContentType.put("js", "application/javascript");
+        extensionToContentType.put("ico", "image/x-icon");
+        extensionToContentType.put("png", "image/png");
+        extensionToContentType.put("jpg", "image/jpg");
+        extensionToContentType.put("woff", "font/woff");
+        extensionToContentType.put("ttf", "font/ttf");
+    }
+
+    public static String getDirectory(String extension) {
+        return extensionToDirectoryPath.get(extension);
+    }
+
+    public static String getContentType(String extension) {
+        return extensionToContentType.get(extension);
+    }
+}

--- a/src/main/java/util/ResourceLoader.java
+++ b/src/main/java/util/ResourceLoader.java
@@ -1,5 +1,8 @@
 package util;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -10,9 +13,21 @@ import static util.RequestParserUtil.getFileExtension;
 
 public class ResourceLoader {
 
+    private static final Logger logger = LoggerFactory.getLogger(ResourceLoader.class);
+
     public static final String url = "/Users/admin/Softeer/be-was/src/main/resources";
 
     public static byte[] loadResource(String resourcePath) throws IOException {
+        logger.debug("resourcePath: " + resourcePath);
+
+        String extension = getFileExtension(resourcePath);
+
+        if(extension.equals("html")) {
+            return Files.readAllBytes(Paths.get( url+ "/templates" + resourcePath));
+        } else if(extension.equals("css") || extension.equals("js") || extension.equals("woff") || extension.equals("ttf") || extension.equals("ico") || extension.equals("png") || extension.equals("jpg")) {
+            return Files.readAllBytes(Paths.get( url+ "/static" + resourcePath));
+        }
+
         return Files.readAllBytes(Paths.get( url+ "/templates" + resourcePath));
     }
 

--- a/src/main/java/util/ResourceLoader.java
+++ b/src/main/java/util/ResourceLoader.java
@@ -1,5 +1,6 @@
 package util;
 
+import controller.ResourcePathMapping;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,14 +22,9 @@ public class ResourceLoader {
         logger.debug("resourcePath: " + resourcePath);
 
         String extension = getFileExtension(resourcePath);
+        String directory = ResourcePathMapping.getDirectory(extension);
 
-        if(extension.equals("html")) {
-            return Files.readAllBytes(Paths.get( url+ "/templates" + resourcePath));
-        } else if(extension.equals("css") || extension.equals("js") || extension.equals("woff") || extension.equals("ttf") || extension.equals("ico") || extension.equals("png") || extension.equals("jpg")) {
-            return Files.readAllBytes(Paths.get( url+ "/static" + resourcePath));
-        }
-
-        return Files.readAllBytes(Paths.get( url+ "/templates" + resourcePath));
+        return Files.readAllBytes(Paths.get( url + directory + resourcePath));
     }
 
     public static String getResourceType(String targetUrl) {

--- a/src/main/java/util/ResponseBuilder.java
+++ b/src/main/java/util/ResponseBuilder.java
@@ -1,5 +1,6 @@
 package util;
 
+import controller.ResourcePathMapping;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,27 +22,7 @@ public class ResponseBuilder {
         String targetPath = tokens[1];
 
         String extension = RequestParserUtil.getFileExtension(targetPath);
-        String contentType;
-
-        if(extension.equals("html")) {
-            contentType = "text/html";
-        } else if(extension.equals("css")) {
-            contentType = "text/css";
-        } else if(extension.equals("js")) {
-            contentType = "application/javascript";
-        } else if(extension.equals("woff")) {
-            contentType = "font/" + extension;
-        } else if(extension.equals("ttf")) {
-            contentType = "font/" + extension;
-        } else if(extension.equals("ico")) {
-            contentType = "image/x-icon";
-        } else if(extension.equals("png")) {
-            contentType = "image/png";
-        } else if(extension.equals("jpg")) {
-            contentType = "image/jpg";
-        } else {
-            contentType = "text/html";
-        }
+        String contentType = ResourcePathMapping.getContentType(extension);
 
         byte[] body;
 

--- a/src/main/java/util/ResponseBuilder.java
+++ b/src/main/java/util/ResponseBuilder.java
@@ -20,11 +20,34 @@ public class ResponseBuilder {
         String statusCode = tokens[0];
         String targetPath = tokens[1];
 
+        String extension = RequestParserUtil.getFileExtension(targetPath);
+        String contentType;
+
+        if(extension.equals("html")) {
+            contentType = "text/html";
+        } else if(extension.equals("css")) {
+            contentType = "text/css";
+        } else if(extension.equals("js")) {
+            contentType = "application/javascript";
+        } else if(extension.equals("woff")) {
+            contentType = "font/" + extension;
+        } else if(extension.equals("ttf")) {
+            contentType = "font/" + extension;
+        } else if(extension.equals("ico")) {
+            contentType = "image/x-icon";
+        } else if(extension.equals("png")) {
+            contentType = "image/png";
+        } else if(extension.equals("jpg")) {
+            contentType = "image/jpg";
+        } else {
+            contentType = "text/html";
+        }
+
         byte[] body;
 
         if(statusCode.equals("200")) {
             body = ResourceLoader.loadResource(targetPath);
-            response200Header(dos, body.length);
+            response200Header(dos, body.length, contentType);
             responseBody(dos, body);
         } else if(statusCode.equals("302")) {
             response302Header(dos, targetPath);
@@ -41,10 +64,10 @@ public class ResponseBuilder {
             return;
         }
     }
-    private static void response200Header(DataOutputStream dos, int lengthOfBodyContent) {
+    private static void response200Header(DataOutputStream dos, int lengthOfBodyContent, String contentType) {
         try {
             dos.writeBytes("HTTP/1.1 200 OK \r\n");
-            dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
+            dos.writeBytes("Content-Type: " + contentType + ";charset=utf-8\r\n");
             dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
             dos.writeBytes("\r\n");
         } catch (IOException e) {

--- a/src/test/java/controller/ResourcePathMappingTest.java
+++ b/src/test/java/controller/ResourcePathMappingTest.java
@@ -1,0 +1,68 @@
+package controller;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.stream.Stream;
+
+public class ResourcePathMappingTest {
+    @ParameterizedTest
+    @ValueSource(strings = {"html", "css", "js", "ico", "png", "jpg", "woff", "ttf"})
+    void testGetDirectory(String extensions) {
+        // Given
+        String expect = getExpectDirectory(extensions);
+
+        // When
+        String actual = ResourcePathMapping.getDirectory(extensions);
+
+        // Then
+        assertThat(actual).isEqualTo(expect)
+                .withFailMessage("확장자 %s의 경로는 %s여야합니다.", extensions, expect);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"html", "css", "js", "ico", "png", "jpg", "woff", "ttf"})
+    void testGetContentType(String extensions) {
+        // Given
+        String expect = getExpectContentType(extensions);
+
+        // When
+        String actual = ResourcePathMapping.getContentType(extensions);
+
+        // Then
+        assertThat(actual).isEqualTo(expect)
+                .withFailMessage("확장자 %s의 Content-Type은 %s여야합니다.", extensions, expect);
+
+    }
+
+    private String getExpectDirectory(String extension) {
+        if(extension.equals("html")) {
+            return "/templates";
+        }
+        return "/static";
+    }
+
+    private String getExpectContentType(String extension) {
+        switch (extension) {
+            case "html":
+                return "text/html";
+            case "css":
+                return "text/css";
+            case "js":
+                return "application/javascript";
+            case "ico":
+                return "image/x-icon";
+            case "png":
+                return "image/png";
+            case "jpg":
+                return "image/jpg";
+            case "woff":
+                return "font/woff";
+            case "ttf":
+                return "font/ttf";
+            default:
+                throw new IllegalArgumentException("지원하지 않는 확장자 입니다 : " + extension);
+        }
+    }
+}


### PR DESCRIPTION
## 구현 내용
### 1. 스타일 시트 지원
> - 파일 형식 지정을 위해 MIME 타입을 HTTP 응답에 추가
> - 각 확장자에 맞는 타입을 매핑한다.

### 2. ResourcePathMapping 클래스 구현
> - 확장자에 따라 파일이 저장된 경로와 컨텐츠 타입을 매핑하는 기능을 클래스로 격리
> - 기존에는 조건문으로 분기하여 컨트롤러에 작성했는데, 컨트롤러의 책임이 아니라고 판단하여 격리

### 3. 테스트 코드 작성
> - 확장자 입력에 따라 의도한 대로 동작하는지 검증

## 고민 사항
- Content-Type 지정방식
> 1. 확장자 별로 조건문으로 분기하여 값을 매핑
> 2. 확장자 별로 해시에 값을 저장하여 매핑
> 3. HTTP 요청에 담긴 타입으로 매핑
>
> 2번과 3번이 적절한 방식이라고 판단했는데, 3번은 font에 대한 매핑이 일관적이지 않게 되어서 2번 방식으로 타입을 매핑하도록 결정했다.

## 기타
> step2에 리팩토링 등의 과정을 많이 진행해서 step3와 커밋의 수가 차이난다.
이후에는 조금 양을 조절해야겠다.

> 그리고 각 스텝을 시작하기 전에 단계별 계획을 수립해야겠다.
(미션 이해 -> 미션 학습 -> 미션 풀이)
