### PR TITLE
[Hymin2] step-3 다양한 컨텐츠 타입 지원

### DIFF
--- a/src/main/java/webserver/handler/RequestHandler.java
+++ b/src/main/java/webserver/handler/RequestHandler.java
@@ -11,13 +11,10 @@ import webserver.type.ContentType;
 
 import java.io.*;
 import java.net.Socket;
-import java.net.URL;
-import java.nio.file.Files;
 
 public class RequestHandler implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
-    private final URL RESOURCES_URL = this.getClass().getClassLoader().getResource("./templates");
-    private Socket connection;
+    private final Socket connection;
 
     public RequestHandler(Socket connectionSocket) {
         this.connection = connectionSocket;
@@ -45,11 +42,9 @@ public class RequestHandler implements Runnable {
 
         try{
             if(requestHeader.getMethod().equals("GET")){
-                File file = new File(RESOURCES_URL.getPath() + requestHeader.getPath());
+                response = ResourceHandler.run(requestHeader);
 
-                if(!file.isDirectory() && file.exists()) {
-                    response = Response.onSuccess(ContentType.HTML, Files.readAllBytes(file.toPath()));
-                } else{
+                if(response == null){
                     Object result = GetRequestHandler.run(GetRequestParser.parse(requestHeader.getPath()));
 
                     if (result instanceof Response) {

--- a/src/main/java/webserver/handler/ResourceHandler.java
+++ b/src/main/java/webserver/handler/ResourceHandler.java
@@ -1,0 +1,56 @@
+package webserver.handler;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import webserver.header.RequestHeader;
+import webserver.response.Response;
+import webserver.type.ContentType;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+
+public class ResourceHandler {
+    private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
+
+    private static final URL HTML_BASE_URL = ResourceHandler.class.getClassLoader().getResource("./templates");
+    private static final URL OTHERS_BASE_URL = ResourceHandler.class.getClassLoader().getResource("./static");
+
+    public static Response run(RequestHeader requestHeader) throws IOException {
+        String path = requestHeader.getPath();
+        String requestFileExtension = getRequestFileExtension(path);
+
+        logger.debug(requestFileExtension);
+
+        ContentType contentType = ContentType.findContentType(requestFileExtension);
+
+        if(contentType == null){
+            return null;
+        }
+
+        File file = getRequestFile(path, requestFileExtension);
+
+        return makeResponse(file, contentType);
+    }
+
+    private static Response makeResponse(File file, ContentType contentType) throws IOException {
+        if(!file.isDirectory() && file.exists()) {
+            return Response.onSuccess(contentType, Files.readAllBytes(file.toPath()));
+        }
+
+        return null;
+    }
+
+    private static File getRequestFile(String path, String requestFileExtension){
+        if(requestFileExtension.equals("html")){
+            return new File(HTML_BASE_URL.getPath() + path);
+        }
+
+        return new File(OTHERS_BASE_URL.getPath() + path);
+    }
+
+    private static String getRequestFileExtension(String path){
+        return path.substring(path.lastIndexOf(".") + 1);
+    }
+}

--- a/src/main/java/webserver/type/ContentType.java
+++ b/src/main/java/webserver/type/ContentType.java
@@ -1,7 +1,18 @@
 package webserver.type;
 
+import java.util.Arrays;
+
 public enum ContentType {
-    HTML("text/html");
+    HTML("text/html"),
+    CSS("text/css"),
+    JS("text/javascript"),
+    ICO("image/x-icon"),
+    PNG("image/png"),
+    JPG("image/jpg"),
+    WOFF("font/woff"),
+    TTF("font/ttf"),
+    SVG("font/svg");
+
     private final String value;
 
     ContentType(String value){
@@ -10,5 +21,12 @@ public enum ContentType {
 
     public String getValue() {
         return value;
+    }
+
+    public static ContentType findContentType(String fileExtension){
+        return Arrays.stream(ContentType.values())
+                .filter((type) -> type.name().equals(fileExtension.toUpperCase()))
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/src/test/java/webserver/handler/GetRequestHandlerTest.java
+++ b/src/test/java/webserver/handler/GetRequestHandlerTest.java
@@ -1,4 +1,4 @@
-package handler;
+package webserver.handler;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/webserver/handler/ResourceHandlerTest.java
+++ b/src/test/java/webserver/handler/ResourceHandlerTest.java
@@ -1,0 +1,68 @@
+package webserver.handler;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import webserver.header.RequestHeader;
+import webserver.response.Response;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ResourceHandlerTest {
+    private final URL HTML_BASE_URL = ResourceHandler.class.getClassLoader().getResource("./templates");
+    private final URL OTHERS_BASE_URL = ResourceHandler.class.getClassLoader().getResource("./static");
+
+    @Test
+    @DisplayName("/index.html 파일을 요청할 때 테스트")
+    void requestIndexHtml() throws IOException {
+        RequestHeader requestHeader = RequestHeader.of("GET", "/index.html", "HTTP/1.1");
+
+        Response response = ResourceHandler.run(requestHeader);
+
+        File file = new File(HTML_BASE_URL.getPath() + "/index.html");
+        byte[] fileBytes = Files.readAllBytes(file.toPath());
+
+        assertEquals(true, isSame(fileBytes, response.getBody()));
+    }
+
+    @Test
+    @DisplayName("/css/styles.css 파일을 요청할 때 테스트")
+    void requestStyleCss() throws IOException {
+        RequestHeader requestHeader = RequestHeader.of("GET", "/css/styles.css", "HTTP/1.1");
+
+        Response response = ResourceHandler.run(requestHeader);
+
+        File file = new File(OTHERS_BASE_URL.getPath() + "/css/styles.css");
+        byte[] fileBytes = Files.readAllBytes(file.toPath());
+
+        assertEquals(true, isSame(fileBytes, response.getBody()));
+    }
+
+    @Test
+    @DisplayName("/index1.html 파일을 요청할 때 예외 테스트")
+    void requestIndex1Html() throws IOException {
+        RequestHeader requestHeader = RequestHeader.of("GET", "/index1.html", "HTTP/1.1");
+
+        Response response = ResourceHandler.run(requestHeader);
+
+        assertNull(response);
+    }
+
+    private boolean isSame(byte[] expected, byte[] actual){
+        if(expected.length != actual.length){
+            return false;
+        }
+
+        for(int i = 0; i < expected.length; i++){
+            if(expected[i] != actual[i]){
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/test/java/webserver/parser/GetRequestParserTest.java
+++ b/src/test/java/webserver/parser/GetRequestParserTest.java
@@ -1,4 +1,4 @@
-package parser;
+package webserver.parser;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/webserver/parser/RequestHeaderParserTest.java
+++ b/src/test/java/webserver/parser/RequestHeaderParserTest.java
@@ -1,4 +1,4 @@
-package parser;
+package webserver.parser;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/webserver/type/ContentTypeTest.java
+++ b/src/test/java/webserver/type/ContentTypeTest.java
@@ -1,0 +1,29 @@
+package webserver.type;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class ContentTypeTest {
+    @Test
+    @DisplayName("확장자로 ContentType 찾기 테스트")
+    void findContentTypeTest(){
+        String fileExtension = "css";
+
+        ContentType contentType = ContentType.findContentType(fileExtension);
+
+        assertEquals(ContentType.CSS, contentType);
+    }
+
+    @Test
+    @DisplayName("없는 확장자로 ContentType 찾을 때 null 인지 테스트")
+    void findNonExistsContentTypeTest(){
+        String fileExtension = "csss";
+
+        ContentType contentType = ContentType.findContentType(fileExtension);
+
+        assertNull(contentType);
+    }
+}


### PR DESCRIPTION
## 구현 내용

### **ResuoureHandler** 구현

`ResourceHandler`란 파일에 대한 GET 요청이 왔을 경우 처리를 해주는 객체입니다.
- `path`를 통해 파일의 확장자를 찾음
    - 만약 없는 확장자면 `null`을 반환
    - `null`이 반환되는 이유는 `GET /user/create`와 같은 요청을 처리하기 위함입니다.
- 요청 파일을 가져옴
    - 만약 파일이 없으면 `null` 반환
    - 그 이유는 위와 같음
- 위 과정을 통해 `Response` 객체를 생성 후 반환

### **ContentType enum** 객체 활용

`ContentType` 객체는 다양한 Content Type 지원을 위해 확장자에 대한 MIME를 저장하여 하나의 파일로 관리하기 위해 생성된 객체입니다.
- html, css, js, jpg 등 여러 타입에 대한 MIME를 값으로 가지도록 저장
- 파일 확장자를 통해 ContentType을 찾는 함수 `findContentType` 추가

### 테스트

- `ContentType`에 대한 테스트
    - [v] `css`에 대한 `ContentType`을 찾을 때 `ContentType.CSS`가 반환되는지 테스트
    - [v] `csss`에 대한 `ContentType`을 찾을 때 `null`이 반환되는지 테스트 
- `ResourceHandler`에 대한 테스트
    - [v] 존재하는 파일인 `/index.html`을 요청할 때 올바르게 파일을 반환하는지 테스트
    - [v] 존재하는 파일인 `/css/styles.css`를 요청할 때 올바르게 파일을 반환하는지 테스트
    - [v] 존재하지 않는 파일인 `/index1.html`을 요청할 때  `null`이 반환되는지 테스트
## 고민 사항

### 이번 스텝에서 고민

사실 이번 스텝은 step-2에서 미리 생각해서 구현을 했기 때문에 생각보다 고민할 것이 적었다. 미리 `ContentType`이라는 enum 객체를 생성했었고, `HttpResponse`에 해당 객체를 통해 헤더를 구성했었기 때문이다. 이제 이걸로 어떻게 구현할까에 대한 고민을 조금 했었던 것 같다. 우선 이전에는 `RequestHandler`에서 파일을 가져오고 응답을 생성했었는데, 이 부분을 `ResourceHandler`라는 객체를 생성해 이 객체에서 파일 요청에 대한 처리를 하도록 구현했다. 처리됐으면 `Response` 객체를 반환하고, 아니면 null을 반환한다. 이전에 구현한 `GetRequestHanlder`랑 비슷하다. 몇 가지 케이스가 되질 않아 테스트도 금방 작성했다. 

하지만 모든 확장자에 대한 것을 `ContentType` 객체에 등록해야 해서 다른 확장자가 생기면 일일이 추가해줘야 한다. 매우 귀찮은 일이다. 요청온 대로 해줄 수 있을텐데 만약 요청 콘텐츠 타입이 */*로 왔을 때 그대로 */*로 보내줘도 괜찮은건가? 아닐거같다.. 그러면 모두 */*로 보내면 되지 굳이 지정해줄 필요는 없을 것 같다.. 이건 일단 그대로 해야할 것 같다.

### 다음 스텝에 대한 고민

다음 스텝의 미션을 봤을 때 내 기존 구조를 또 변경해야 할 것 같다는 생각이 들었다. 요청과 응답 헤더에 형식이 달라졌을 때를 고려하지 않았기 때문이다. 이 부분은 다음 스텝을 진행해보면서 알아보도록 하겠다..