### PR TITLE
[swkim0911] 웹 서버 4단계 - POST로 회원 가입

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Java Web Application Server 2023
 를 참고하여 작성되었습니다.
 
 
-# 학습 내용
+# 학습 내용 step 1
 
 ## 자바 스레드 생명주기
 
@@ -72,6 +72,22 @@ Virtual Thread는 기존 Java의 스레드 모델과 달리, 플랫폼 스레드
 ### Java Thread 기반 코드에서 Concurrent 패키지를 사용한 이유
 
 jdk 17 기준으로 Java에서는 사용자 수준 스레드와 커널 수준 스레드가 각각 존재하며, 사용자 수준 스레드를  커널 수준 스레드에 매핑하는 방식으로 동작한다. 커널 수준 스레드는 OS의 지원을 받아야 하므로 스레드를 매번 요청마다 생성하고 종료하는 것은 시스템의 자원이 많이 소모되고, 성능이 저하된다. 그래서 미리 일정 개수의 스레드를 생성하고 관리하는 스레드 풀을 사용하는게 효과적인데 Concurrent 패키지의 ExecutorService 인터페이스와 Executors 유틸리티 클래스가 스레드 풀을 사용할 수 있는 api를 제공한다.
+
+# 학습 내용 step 4
+
+## HTTP request body를 읽어들일 때 br.readLine() 함수가 아닌 br.read() 함수를 사용한 이유
+
+br.readLine() 함수의 Api 문서를 보면 이렇게 쓰여있다.
+
+> Reads a line of text.  A line is considered to be terminated by any one of a line feed ('\n'), a carriage return ('\r'), a carriage return followed immediately by a line feed, or by reaching the end-of-file (EOF).
+
+br.readLine() 함수는 텍스트의 한 line을 읽는데 이 line은 ‘\n’, ‘\r’, ‘\r\n’, 이나 EOF에 도달하여 끝나는 것을 line으로 한다.
+
+하지만 HTTP 프로토콜에서는 일반적으로 EOF를 명시적으로 표시하지 않는다.  HTTP 메시지의 끝은 Content-Length 헤더를 통해 명시된 길이에 따라 결정되거나, Transfer-Encoding 헤더가 chunked로 설정되어 있다면 각 청크의 끝에 해당하는 CRLF가 사용된다. 따라서 EOF는 명시적으로 표시되는 것이 아니라, 프로토콜 및 헤더에 따라 메시지의 끝을 결정된다.
+
+따라서 body를 읽기 위해 br.readLine() 함수를 쓴다면 EOF를 만나지 못해 계속 무한루프를 돈다. 
+
+body를 읽어오기 위해서 Content-Length를 사용해야 한다. br.read(char[] buf) 함수는 buf의 크기 만큼 스트림에서 읽어오는데 buf 배열의 크기를 Content-Length 크기만큼 할당하고 읽어오면 body를 읽어올 수 있다.
 
 ## Reference
 - [Java의 미래, Virtual Thread - 김태헌](https://techblog.woowahan.com/15398/)

--- a/src/main/java/handler/HomeRequestHandler.java
+++ b/src/main/java/handler/HomeRequestHandler.java
@@ -11,6 +11,6 @@ public class HomeRequestHandler implements RequestHandler{
         if (uri.equals("/")) {
             uri = "/index.html";
         }
-        return getHttpResponse(httpRequest, uri);
+        return getHttpResponse(httpRequest.getVersion(), uri);
     }
 }

--- a/src/main/java/handler/RequestHandler.java
+++ b/src/main/java/handler/RequestHandler.java
@@ -2,8 +2,10 @@ package handler;
 
 import http.HttpRequest;
 import http.HttpResponse;
+import http.status.HttpStatusCode;
 import util.FileUtils;
 import util.HttpResponseUtils;
+import util.UriParser;
 
 import java.util.Optional;
 
@@ -14,11 +16,12 @@ public interface RequestHandler {
     default HttpResponse getHttpResponse(HttpRequest httpRequest, String uri){
         Optional<byte[]> body = FileUtils.readFile(uri);
         if (body.isPresent()) {
-            return HttpResponseUtils.get200HttpResponse(httpRequest, body.get());
+			return HttpResponseUtils.getHttpResponse(HttpStatusCode.OK, httpRequest.getVersion(), UriParser.getFileType(uri), body.get());
         }
 		//body가 empty라면 404 페이지 전송
-		body = FileUtils.readFile("/error/404.html1");
+		body = FileUtils.readFile("/error/404.html");
 		//404 페이지를 찾을 수 없으면 "404 NOT FOUND 문자열 전송"
-		return HttpResponseUtils.get404HttpResponse(httpRequest, body.orElse("404 NOT FOUND".getBytes()));
+		return HttpResponseUtils.getHttpResponse(HttpStatusCode.NOT_FOUND, httpRequest.getVersion(),
+			UriParser.getFileType(uri), body.orElse("404 NOT FOUND".getBytes()));
     }
 }

--- a/src/main/java/handler/RequestHandler.java
+++ b/src/main/java/handler/RequestHandler.java
@@ -13,15 +13,15 @@ import java.util.Optional;
 public interface RequestHandler {
     HttpResponse handle(HttpRequest httpRequest);
 
-    default HttpResponse getHttpResponse(HttpRequest httpRequest, String uri){
+    default HttpResponse getHttpResponse(String version, String uri){
         Optional<byte[]> body = FileUtils.readFile(uri);
         if (body.isPresent()) {
-			return HttpResponseUtils.getHttpResponse(HttpStatusCode.OK, httpRequest.getVersion(), UriParser.getFileType(uri), body.get());
+			return HttpResponseUtils.getHttpResponse(HttpStatusCode.OK, version, UriParser.getFileType(uri), body.get());
         }
 		//body가 empty라면 404 페이지 전송
 		body = FileUtils.readFile("/error/404.html");
 		//404 페이지를 찾을 수 없으면 "404 NOT FOUND 문자열 전송"
-		return HttpResponseUtils.getHttpResponse(HttpStatusCode.NOT_FOUND, httpRequest.getVersion(),
+		return HttpResponseUtils.getHttpResponse(HttpStatusCode.NOT_FOUND, version,
 			UriParser.getFileType(uri), body.orElse("404 NOT FOUND".getBytes()));
     }
 }

--- a/src/main/java/handler/RequestHandler.java
+++ b/src/main/java/handler/RequestHandler.java
@@ -16,8 +16,9 @@ public interface RequestHandler {
         if (body.isPresent()) {
             return HttpResponseUtils.get200HttpResponse(httpRequest, body.get());
         }
-         body = FileUtils.readFile("/error/404.html"); //body가 empty라면 404 페이지 전송
-        // 404 페이지를 못찾아서 body가 empty라면 이때는 언체크 예외로 RuntimeException
-        return HttpResponseUtils.get404HttpResponse(httpRequest, body.orElseThrow(RuntimeException::new));
+		//body가 empty라면 404 페이지 전송
+		body = FileUtils.readFile("/error/404.html1");
+		//404 페이지를 찾을 수 없으면 "404 NOT FOUND 문자열 전송"
+		return HttpResponseUtils.get404HttpResponse(httpRequest, body.orElse("404 NOT FOUND".getBytes()));
     }
 }

--- a/src/main/java/handler/UserRequestHandler.java
+++ b/src/main/java/handler/UserRequestHandler.java
@@ -7,6 +7,7 @@ import model.User;
 import util.HttpResponseUtils;
 import util.QueryStringParser;
 
+import java.util.Collection;
 import java.util.Map;
 
 
@@ -15,10 +16,10 @@ public class UserRequestHandler implements RequestHandler{
     public HttpResponse handle(HttpRequest httpRequest){
         String uri = httpRequest.getUri();
         if (uri.equals("/user/create")) {
-            Map<String, String> parameters = QueryStringParser.getParameters(httpRequest.getQueryString());
+			Map<String, String> parameters = QueryStringParser.getParameters(httpRequest.getBody().get());
             User user = User.create(parameters);
             Database.addUser(user);
-            // index.html 으로 리다이렉트
+			// index.html 으로 리다이렉트
             return HttpResponseUtils.get302HttpResponse(httpRequest);
         }
         return getHttpResponse(httpRequest, uri);

--- a/src/main/java/handler/UserRequestHandler.java
+++ b/src/main/java/handler/UserRequestHandler.java
@@ -3,6 +3,7 @@ package handler;
 import http.HttpRequest;
 import http.HttpResponse;
 import db.Database;
+import http.status.HttpStatusCode;
 import model.User;
 import util.HttpResponseUtils;
 import util.QueryStringParser;
@@ -13,13 +14,14 @@ public class UserRequestHandler implements RequestHandler{
     @Override
     public HttpResponse handle(HttpRequest httpRequest){
         String uri = httpRequest.getUri();
+		String version = httpRequest.getVersion();
         if (uri.equals("/user/create")) {
 			Map<String, String> parameters = QueryStringParser.getParameters(httpRequest.getBody());
             User user = User.create(parameters);
             Database.addUser(user);
 			// index.html 으로 리다이렉트
-            return HttpResponseUtils.get302HttpResponse(httpRequest);
+			return HttpResponseUtils.get302HttpResponse(HttpStatusCode.FOUND, version);
         }
-        return getHttpResponse(httpRequest, uri);
+        return getHttpResponse(version, uri);
     }
 }

--- a/src/main/java/handler/UserRequestHandler.java
+++ b/src/main/java/handler/UserRequestHandler.java
@@ -7,16 +7,14 @@ import model.User;
 import util.HttpResponseUtils;
 import util.QueryStringParser;
 
-import java.util.Collection;
 import java.util.Map;
-
 
 public class UserRequestHandler implements RequestHandler{
     @Override
     public HttpResponse handle(HttpRequest httpRequest){
         String uri = httpRequest.getUri();
         if (uri.equals("/user/create")) {
-			Map<String, String> parameters = QueryStringParser.getParameters(httpRequest.getBody().get());
+			Map<String, String> parameters = QueryStringParser.getParameters(httpRequest.getBody());
             User user = User.create(parameters);
             Database.addUser(user);
 			// index.html 으로 리다이렉트

--- a/src/main/java/http/HttpRequest.java
+++ b/src/main/java/http/HttpRequest.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
+import java.util.Optional;
 
 public class HttpRequest {
     private static final Logger logger = LoggerFactory.getLogger(HttpRequest.class);
@@ -13,12 +14,15 @@ public class HttpRequest {
     private final String version;
     private final Map<String, String> headerFields;
 
-    public HttpRequest(String method, String uri, String queryString, String version, Map<String, String> headerFields) {
+	private final Optional<String> body;
+
+    public HttpRequest(String method, String uri, String queryString, String version, Map<String, String> headerFields, Optional<String> body) {
         this.method = method;
         this.uri = uri;
         this.queryString = queryString;
         this.version = version;
         this.headerFields = headerFields;
+        this.body = body;
     }
 
     public String getMethod() {
@@ -41,7 +45,11 @@ public class HttpRequest {
         return headerFields;
     }
 
-    public void logHeaders(){
+	public Optional<String> getBody() {
+		return body;
+	}
+
+	public void logHeaders(){ // 바디도 같이 찍기
         StringBuilder sb = new StringBuilder();
         sb.append("\n").append("Method: ").append(method).append("\n");
         sb.append("Uri: ").append(uri).append("\n");

--- a/src/main/java/http/HttpRequest.java
+++ b/src/main/java/http/HttpRequest.java
@@ -13,7 +13,6 @@ public class HttpRequest {
     private final String queryString; // 없는 경우 None
     private final String version;
     private final Map<String, String> headerFields;
-
 	private final Optional<String> body;
 
     public HttpRequest(String method, String uri, String queryString, String version, Map<String, String> headerFields, Optional<String> body) {
@@ -58,6 +57,7 @@ public class HttpRequest {
         for (Map.Entry<String, String> entry : headerFields.entrySet()) {
             sb.append(entry.getKey()).append(": ").append(entry.getValue()).append("\n");
         }
-        logger.debug("{}", sb);
-    }
+		logger.debug("{}", sb.toString().trim());
+
+	}
 }

--- a/src/main/java/http/HttpRequest.java
+++ b/src/main/java/http/HttpRequest.java
@@ -4,7 +4,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
-import java.util.Optional;
 
 public class HttpRequest {
     private static final Logger logger = LoggerFactory.getLogger(HttpRequest.class);
@@ -13,9 +12,9 @@ public class HttpRequest {
     private final String queryString; // 없는 경우 None
     private final String version;
     private final Map<String, String> headerFields;
-	private final Optional<String> body;
+	private final String body; // 없는 경우 "" (empty)
 
-    public HttpRequest(String method, String uri, String queryString, String version, Map<String, String> headerFields, Optional<String> body) {
+    public HttpRequest(String method, String uri, String queryString, String version, Map<String, String> headerFields, String body) {
         this.method = method;
         this.uri = uri;
         this.queryString = queryString;
@@ -44,7 +43,7 @@ public class HttpRequest {
         return headerFields;
     }
 
-	public Optional<String> getBody() {
+	public String getBody() {
 		return body;
 	}
 
@@ -57,7 +56,7 @@ public class HttpRequest {
         for (Map.Entry<String, String> entry : headerFields.entrySet()) {
             sb.append(entry.getKey()).append(": ").append(entry.getValue()).append("\n");
         }
-		sb.append("Body: ").append(body.orElse(""));
+		sb.append("Body: ").append(body);
 		logger.debug("{}", sb.toString().trim());
 
 	}

--- a/src/main/java/http/HttpRequest.java
+++ b/src/main/java/http/HttpRequest.java
@@ -57,6 +57,7 @@ public class HttpRequest {
         for (Map.Entry<String, String> entry : headerFields.entrySet()) {
             sb.append(entry.getKey()).append(": ").append(entry.getValue()).append("\n");
         }
+		sb.append("Body: ").append(body.orElse(""));
 		logger.debug("{}", sb.toString().trim());
 
 	}

--- a/src/main/java/http/HttpRequestFactory.java
+++ b/src/main/java/http/HttpRequestFactory.java
@@ -1,6 +1,8 @@
 package http;
 
 import http.builder.HttpRequestBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import util.HttpRequestHeaderUtils;
 
 import java.io.BufferedReader;
@@ -8,17 +10,25 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URLDecoder;
+import java.util.Map;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class HttpRequestFactory {
 
+	private static final Logger logger = LoggerFactory.getLogger(HttpRequestFactory.class);
     public static HttpRequest getRequest(InputStream in) throws IOException {
-		String requestHeader = URLDecoder.decode(getRequestHeader(in), UTF_8);
-//		String requestBody = getRequestBody(in);
+		BufferedReader br = new BufferedReader(new InputStreamReader(in));
+		String requestHeader = URLDecoder.decode(getRequestHeader(br), UTF_8);
 		HttpRequestHeaderUtils httpRequestHeaderUtils = HttpRequestHeaderUtils.createHeaderUtils(requestHeader);
-
-        return new HttpRequestBuilder()
+		Map<String, String> map = httpRequestHeaderUtils.getRequestHeaders();
+		String contentLength = map.get("Content-Length");
+		if (contentLength != null) {
+			char[] buf = new char[Integer.parseInt(contentLength)];
+			br.read(buf);
+			System.out.println("buf = " + String.valueOf(buf));
+		}
+		return new HttpRequestBuilder()
                 .method(httpRequestHeaderUtils.getRequestMethod())
                 .uri(httpRequestHeaderUtils.getRequestUri())
                 .queryString(httpRequestHeaderUtils.getQueryString())
@@ -27,15 +37,24 @@ public class HttpRequestFactory {
                 .build();
     }
 
-    private static String getRequestHeader(InputStream in) throws IOException { //헤더를 읽는 메서드로 변환
+    private static String getRequestHeader(BufferedReader br) throws IOException { //헤더를 읽는 메서드로 변환
         StringBuilder sb = new StringBuilder();
-        BufferedReader br = new BufferedReader(new InputStreamReader(in));
-		String line;
-		while (!(line = br.readLine()).isEmpty()) {
+		String line = br.readLine();
+		sb.append(line).append("\r\n");
+		while (!line.isEmpty()) { //마지막 라인 = ""(empty)
+			line = br.readLine();
 			sb.append(line).append("\r\n");
 		}
-        return sb.toString().trim();
+		return sb.toString().trim();
     }
 
 	//todo inputstream을 이어 받아서 body를 String 변환
+	private static String getRequestBody(BufferedReader br) throws IOException {
+		StringBuilder sb = new StringBuilder();
+		String line;
+		while ((line = br.readLine()) != null) { //eof 만날때까지
+			sb.append(line).append("\r\n");
+		}
+		return sb.toString();
+	}
 }

--- a/src/main/java/http/HttpRequestFactory.java
+++ b/src/main/java/http/HttpRequestFactory.java
@@ -1,8 +1,6 @@
 package http;
 
 import http.builder.HttpRequestBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import util.HttpRequestHeaderUtils;
 
 import java.io.BufferedReader;
@@ -16,12 +14,12 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class HttpRequestFactory {
 
-	private static final Logger logger = LoggerFactory.getLogger(HttpRequestFactory.class);
     public static HttpRequest getRequest(InputStream in) throws IOException {
 		BufferedReader br = new BufferedReader(new InputStreamReader(in));
 		String requestHeader = URLDecoder.decode(getRequestHeader(br), UTF_8);
 		HttpRequestHeaderUtils httpRequestHeaderUtils = HttpRequestHeaderUtils.createHeaderUtils(requestHeader);
 		String requestBody = getRequestBody(httpRequestHeaderUtils, br);
+
 		return new HttpRequestBuilder()
                 .method(httpRequestHeaderUtils.getRequestMethod())
                 .uri(httpRequestHeaderUtils.getRequestUri())
@@ -31,17 +29,6 @@ public class HttpRequestFactory {
 				.body(requestBody)
                 .build();
     }
-
-	private static String getRequestBody(HttpRequestHeaderUtils httpRequestHeaderUtils, BufferedReader br) throws IOException {
-		Map<String, String> map = httpRequestHeaderUtils.getRequestHeaders();
-		String contentLength = map.get("Content-Length");
-		if (contentLength != null) {
-			char[] buf = new char[Integer.parseInt(contentLength)];
-			br.read(buf);
-			return URLDecoder.decode(String.valueOf(buf), UTF_8);
-		}
-		return null;
-	}
 
 	private static String getRequestHeader(BufferedReader br) throws IOException { //헤더를 읽는 메서드로 변환
         StringBuilder sb = new StringBuilder();
@@ -54,13 +41,14 @@ public class HttpRequestFactory {
 		return sb.toString().trim();
     }
 
-	//todo inputstream을 이어 받아서 body를 String 변환
-	private static String getRequestBody(BufferedReader br) throws IOException {
-		StringBuilder sb = new StringBuilder();
-		String line;
-		while ((line = br.readLine()) != null) { //eof 만날때까지
-			sb.append(line).append("\r\n");
+	private static String getRequestBody(HttpRequestHeaderUtils httpRequestHeaderUtils, BufferedReader br) throws IOException {
+		Map<String, String> map = httpRequestHeaderUtils.getRequestHeaders();
+		String contentLength = map.get("Content-Length");
+		if (contentLength != null) {
+			char[] buf = new char[Integer.parseInt(contentLength)];
+			br.read(buf);
+			return URLDecoder.decode(String.valueOf(buf), UTF_8);
 		}
-		return sb.toString();
+		return "";
 	}
 }

--- a/src/main/java/http/HttpRequestFactory.java
+++ b/src/main/java/http/HttpRequestFactory.java
@@ -14,8 +14,9 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public class HttpRequestFactory {
 
     public static HttpRequest getRequest(InputStream in) throws IOException {
-        String requestMessage = URLDecoder.decode(getStringRequestMessage(in), UTF_8);
-        HttpRequestHeaderUtils httpRequestHeaderUtils = HttpRequestHeaderUtils.createHeaderUtils(requestMessage);
+		String requestHeader = URLDecoder.decode(getRequestHeader(in), UTF_8);
+//		String requestBody = getRequestBody(in);
+		HttpRequestHeaderUtils httpRequestHeaderUtils = HttpRequestHeaderUtils.createHeaderUtils(requestHeader);
 
         return new HttpRequestBuilder()
                 .method(httpRequestHeaderUtils.getRequestMethod())
@@ -26,15 +27,15 @@ public class HttpRequestFactory {
                 .build();
     }
 
-    private static String getStringRequestMessage(InputStream in) throws IOException {
+    private static String getRequestHeader(InputStream in) throws IOException { //헤더를 읽는 메서드로 변환
         StringBuilder sb = new StringBuilder();
         BufferedReader br = new BufferedReader(new InputStreamReader(in));
-        String line = br.readLine();
-        sb.append(line).append("\r\n");
-        while (!line.isEmpty()) { //마지막 라인 = ""(empty)
-            line = br.readLine();
-            sb.append(line).append("\r\n");
-        }
+		String line;
+		while (!(line = br.readLine()).isEmpty()) {
+			sb.append(line).append("\r\n");
+		}
         return sb.toString().trim();
     }
+
+	//todo inputstream을 이어 받아서 body를 String 변환
 }

--- a/src/main/java/http/HttpRequestFactory.java
+++ b/src/main/java/http/HttpRequestFactory.java
@@ -21,23 +21,29 @@ public class HttpRequestFactory {
 		BufferedReader br = new BufferedReader(new InputStreamReader(in));
 		String requestHeader = URLDecoder.decode(getRequestHeader(br), UTF_8);
 		HttpRequestHeaderUtils httpRequestHeaderUtils = HttpRequestHeaderUtils.createHeaderUtils(requestHeader);
-		Map<String, String> map = httpRequestHeaderUtils.getRequestHeaders();
-		String contentLength = map.get("Content-Length");
-		if (contentLength != null) {
-			char[] buf = new char[Integer.parseInt(contentLength)];
-			br.read(buf);
-			System.out.println("buf = " + String.valueOf(buf));
-		}
+		String requestBody = getRequestBody(httpRequestHeaderUtils, br);
 		return new HttpRequestBuilder()
                 .method(httpRequestHeaderUtils.getRequestMethod())
                 .uri(httpRequestHeaderUtils.getRequestUri())
                 .queryString(httpRequestHeaderUtils.getQueryString())
                 .version(httpRequestHeaderUtils.getRequestVersion())
                 .headerFields(httpRequestHeaderUtils.getRequestHeaders())
+				.body(requestBody)
                 .build();
     }
 
-    private static String getRequestHeader(BufferedReader br) throws IOException { //헤더를 읽는 메서드로 변환
+	private static String getRequestBody(HttpRequestHeaderUtils httpRequestHeaderUtils, BufferedReader br) throws IOException {
+		Map<String, String> map = httpRequestHeaderUtils.getRequestHeaders();
+		String contentLength = map.get("Content-Length");
+		if (contentLength != null) {
+			char[] buf = new char[Integer.parseInt(contentLength)];
+			br.read(buf);
+			return URLDecoder.decode(String.valueOf(buf), UTF_8);
+		}
+		return null;
+	}
+
+	private static String getRequestHeader(BufferedReader br) throws IOException { //헤더를 읽는 메서드로 변환
         StringBuilder sb = new StringBuilder();
 		String line = br.readLine();
 		sb.append(line).append("\r\n");

--- a/src/main/java/http/HttpResponse.java
+++ b/src/main/java/http/HttpResponse.java
@@ -9,9 +9,9 @@ public class HttpResponse {
     private final String version;
     private final HttpStatusCode statusCode;
     private final Map<String, String> headerFields;
-    private final Optional<byte[]> body;
+    private final byte[] body;
 
-    public HttpResponse(String version, HttpStatusCode statusCode, Map<String, String> headerFields, Optional<byte[]> body) {
+    public HttpResponse(String version, HttpStatusCode statusCode, Map<String, String> headerFields, byte[] body) {
         this.version = version;
         this.statusCode = statusCode;
         this.headerFields = headerFields;
@@ -30,7 +30,7 @@ public class HttpResponse {
         return headerFields;
     }
 
-    public Optional<byte[]> getBody() {
+    public byte[] getBody() {
         return body;
     }
 

--- a/src/main/java/http/HttpResponseSender.java
+++ b/src/main/java/http/HttpResponseSender.java
@@ -26,9 +26,9 @@ public class HttpResponseSender {
     }
 
     private static void responseBody(DataOutputStream dos, HttpResponse httpResponse) throws IOException {
-        Optional<byte[]> body = httpResponse.getBody();
-        if (body.isPresent()) {
-            dos.write(body.get(), 0, body.get().length);
+        byte[] body = httpResponse.getBody();
+        if (body.length > 0) {
+            dos.write(body, 0, body.length);
         }
     }
 }

--- a/src/main/java/http/HttpResponseSender.java
+++ b/src/main/java/http/HttpResponseSender.java
@@ -25,7 +25,6 @@ public class HttpResponseSender {
         dos.writeBytes(httpResponse.getResponseHeader());
     }
 
-
     private static void responseBody(DataOutputStream dos, HttpResponse httpResponse) throws IOException {
         Optional<byte[]> body = httpResponse.getBody();
         if (body.isPresent()) {

--- a/src/main/java/http/builder/HttpRequestBuilder.java
+++ b/src/main/java/http/builder/HttpRequestBuilder.java
@@ -40,7 +40,7 @@ public class HttpRequestBuilder {
     }
 
 	public HttpRequestBuilder body(String body) {
-		this.body = Optional.of(body);
+		this.body = Optional.ofNullable(body);
 		return this;
 	}
     public HttpRequest build() {

--- a/src/main/java/http/builder/HttpRequestBuilder.java
+++ b/src/main/java/http/builder/HttpRequestBuilder.java
@@ -3,7 +3,6 @@ package http.builder;
 import http.HttpRequest;
 
 import java.util.Map;
-import java.util.Optional;
 
 public class HttpRequestBuilder {
 
@@ -12,7 +11,7 @@ public class HttpRequestBuilder {
     private String queryString;
     private String version;
     private Map<String, String> headerFields;
-	private Optional<String> body;
+	private String body;
 
     public HttpRequestBuilder method(String method) {
         this.method = method;
@@ -40,7 +39,7 @@ public class HttpRequestBuilder {
     }
 
 	public HttpRequestBuilder body(String body) {
-		this.body = Optional.ofNullable(body);
+		this.body = body;
 		return this;
 	}
     public HttpRequest build() {

--- a/src/main/java/http/builder/HttpRequestBuilder.java
+++ b/src/main/java/http/builder/HttpRequestBuilder.java
@@ -3,6 +3,8 @@ package http.builder;
 import http.HttpRequest;
 
 import java.util.Map;
+import java.util.Optional;
+
 public class HttpRequestBuilder {
 
     private String method;
@@ -10,6 +12,7 @@ public class HttpRequestBuilder {
     private String queryString;
     private String version;
     private Map<String, String> headerFields;
+	private Optional<String> body;
 
     public HttpRequestBuilder method(String method) {
         this.method = method;
@@ -35,7 +38,12 @@ public class HttpRequestBuilder {
         this.headerFields = headerFields;
         return this;
     }
+
+	public HttpRequestBuilder body(String body) {
+		this.body = Optional.of(body);
+		return this;
+	}
     public HttpRequest build() {
-        return new HttpRequest(method, uri, queryString, version, headerFields);
+        return new HttpRequest(method, uri, queryString, version, headerFields, body);
     }
 }

--- a/src/main/java/http/builder/HttpResponseBuilder.java
+++ b/src/main/java/http/builder/HttpResponseBuilder.java
@@ -26,7 +26,7 @@ public class HttpResponseBuilder {
     }
 
     public HttpResponseBuilder body(byte[] body) {
-        this.body = Optional.of(body);
+        this.body = Optional.ofNullable(body);
         return this;
     }
 

--- a/src/main/java/http/builder/HttpResponseBuilder.java
+++ b/src/main/java/http/builder/HttpResponseBuilder.java
@@ -10,7 +10,7 @@ public class HttpResponseBuilder {
     private String version;
     private HttpStatusCode statusCode;
     private Map<String, String> headerFields;
-    private Optional<byte[]> body;
+    private byte[] body;
 
     public HttpResponseBuilder version(String version) {
         this.version = version;
@@ -26,7 +26,7 @@ public class HttpResponseBuilder {
     }
 
     public HttpResponseBuilder body(byte[] body) {
-        this.body = Optional.ofNullable(body);
+		this.body = body;
         return this;
     }
 

--- a/src/main/java/util/FileUtils.java
+++ b/src/main/java/util/FileUtils.java
@@ -3,9 +3,10 @@ package util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.Optional;
 
 public class FileUtils {
@@ -16,12 +17,25 @@ public class FileUtils {
         String fileType = UriParser.getFileType(uri);
         try {
             if (fileType.equals("html")) {
-                return Optional.of(Files.readAllBytes(new File(htmlPath + uri).toPath()));
+                return Optional.of(readFileBytes(htmlPath + uri));
             }
-            return Optional.of(Files.readAllBytes(new File(resourcePath + uri).toPath()));
+			return Optional.of(readFileBytes(resourcePath + uri));
         } catch (IOException e) {
             logger.error(e.getMessage());
             return Optional.empty();
         }
     }
+
+	private static byte[] readFileBytes(String filePath) throws IOException {
+		File file = new File(filePath);
+		try (FileInputStream fis = new FileInputStream(file); ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+			byte[] buffer = new byte[1024];
+			int bytesRead;
+
+			while ((bytesRead = fis.read(buffer)) != -1) {
+				bos.write(buffer, 0, bytesRead); //bos에 buffer에서 읽은 만큼 쓰기
+			}
+			return bos.toByteArray();
+		}
+	}
 }

--- a/src/main/java/util/HttpRequestHeaderUtils.java
+++ b/src/main/java/util/HttpRequestHeaderUtils.java
@@ -8,10 +8,10 @@ public class HttpRequestHeaderUtils {
     private HttpRequestHeaderUtils() {
     }
 
-    public static HttpRequestHeaderUtils createHeaderUtils(String requestMessage){
+    public static HttpRequestHeaderUtils createHeaderUtils(String requestHeader){
         HttpRequestHeaderUtils httpRequestHeaderUtils = new HttpRequestHeaderUtils();
-        httpRequestHeaderUtils.requestLineMap = HttpRequestHeaderParser.parseRequestLine(requestMessage);
-        httpRequestHeaderUtils.requestHeaderMap = HttpRequestHeaderParser.parseHeaders(requestMessage);
+        httpRequestHeaderUtils.requestLineMap = HttpRequestHeaderParser.parseRequestLine(requestHeader);
+        httpRequestHeaderUtils.requestHeaderMap = HttpRequestHeaderParser.parseHeaders(requestHeader);
         return httpRequestHeaderUtils;
     }
 

--- a/src/main/java/util/HttpResponseUtils.java
+++ b/src/main/java/util/HttpResponseUtils.java
@@ -26,6 +26,7 @@ public class HttpResponseUtils {
                 .version(httpRequest.getVersion())
                 .status(HttpStatusCode.FOUND)
                 .headerFields(headerFields)
+				.body(new byte[0])
                 .build();
     }
     public static HttpResponse get404HttpResponse(HttpRequest httpRequest, byte[] body) {

--- a/src/main/java/util/HttpResponseUtils.java
+++ b/src/main/java/util/HttpResponseUtils.java
@@ -10,18 +10,18 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class HttpResponseUtils {
-    public static HttpResponse get200HttpResponse(HttpRequest httpRequest, byte[] body) {
-        Map<String, String> headerFields = setHeaderFields200And400Code(httpRequest, body);
+    public static HttpResponse getHttpResponse(HttpStatusCode statusCode, String version, String fileType, byte[] body) {
+        Map<String, String> headerFields = setHeaderFields(fileType, body);
         return new HttpResponseBuilder()
-                .version(httpRequest.getVersion())
-                .status(HttpStatusCode.OK)
+                .version(version)
+                .status(statusCode)
                 .headerFields(headerFields)
                 .body(body)
                 .build();
     }
 
     public static HttpResponse get302HttpResponse(HttpRequest httpRequest) {
-        Map<String, String> headerFields = setHeaderFields300Code();
+        Map<String, String> headerFields = setRedirectionHeader();
         return new HttpResponseBuilder()
                 .version(httpRequest.getVersion())
                 .status(HttpStatusCode.FOUND)
@@ -29,26 +29,16 @@ public class HttpResponseUtils {
 				.body(new byte[0])
                 .build();
     }
-    public static HttpResponse get404HttpResponse(HttpRequest httpRequest, byte[] body) {
-        Map<String, String> headerFields = setHeaderFields200And400Code(httpRequest, body);
-        return new HttpResponseBuilder()
-                .version(httpRequest.getVersion())
-                .status(HttpStatusCode.NOT_FOUND)
-                .headerFields(headerFields)
-                .body(body)
-                .build();
-    }
 
-    private static Map<String, String> setHeaderFields200And400Code(HttpRequest httpRequest, byte[] body) {
+    private static Map<String, String> setHeaderFields(String fileType, byte[] body) {
         Map<String, String> headerFields = new HashMap<>();
-        String fileType = UriParser.getFileType(httpRequest.getUri());
 		String contentType = ContentTypeMapper.getContentType(fileType);
         headerFields.put("Content-Type", contentType + ";charset=utf-8");
         headerFields.put("Content-Length", String.valueOf(body.length));
         return headerFields;
     }
 
-    private static Map<String, String> setHeaderFields300Code() {
+    private static Map<String, String> setRedirectionHeader(){
         Map<String, String> headerFields = new HashMap<>();
         headerFields.put("Content-Type", "text/html;charset=utf-8");
         headerFields.put("Location", "/index.html");

--- a/src/main/java/util/HttpResponseUtils.java
+++ b/src/main/java/util/HttpResponseUtils.java
@@ -41,7 +41,7 @@ public class HttpResponseUtils {
     private static Map<String, String> setHeaderFields200And400Code(HttpRequest httpRequest, byte[] body) {
         Map<String, String> headerFields = new HashMap<>();
         String fileType = UriParser.getFileType(httpRequest.getUri());
-        String contentType = ContentTypeMapper.contentTypeMap.get(fileType);
+		String contentType = ContentTypeMapper.getContentType(fileType);
         headerFields.put("Content-Type", contentType + ";charset=utf-8");
         headerFields.put("Content-Length", String.valueOf(body.length));
         return headerFields;

--- a/src/main/java/util/HttpResponseUtils.java
+++ b/src/main/java/util/HttpResponseUtils.java
@@ -20,11 +20,11 @@ public class HttpResponseUtils {
                 .build();
     }
 
-    public static HttpResponse get302HttpResponse(HttpRequest httpRequest) {
+    public static HttpResponse get302HttpResponse(HttpStatusCode statusCode, String version) {
         Map<String, String> headerFields = setRedirectionHeader();
         return new HttpResponseBuilder()
-                .version(httpRequest.getVersion())
-                .status(HttpStatusCode.FOUND)
+                .version(version)
+                .status(statusCode)
                 .headerFields(headerFields)
 				.body(new byte[0])
                 .build();

--- a/src/main/java/util/mapper/ContentTypeMapper.java
+++ b/src/main/java/util/mapper/ContentTypeMapper.java
@@ -1,6 +1,5 @@
 package util.mapper;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 

--- a/src/main/java/util/mapper/ContentTypeMapper.java
+++ b/src/main/java/util/mapper/ContentTypeMapper.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class ContentTypeMapper {
-    static public Map<String, String> contentTypeMap = new ConcurrentHashMap<>();
+    private static Map<String, String> contentTypeMap = new ConcurrentHashMap<>();
 
 	static {
         contentTypeMap.put("html", "text/html");
@@ -15,4 +15,8 @@ public class ContentTypeMapper {
         contentTypeMap.put("ttf", "font/ttf");
         contentTypeMap.put("ico", "image/x-icon");
     }
+
+	public static String getContentType(String fileType) {
+		return contentTypeMap.get(fileType);
+	}
 }

--- a/src/main/java/webserver/RequestController.java
+++ b/src/main/java/webserver/RequestController.java
@@ -34,7 +34,7 @@ public class RequestController implements Runnable {
     public void handleRequest(HttpRequest httpRequest, OutputStream out) throws IOException {
         String uri = httpRequest.getUri();
         RequestHandler requestHandler;
-        if (uri.startsWith("/user")) { //todo get, post메서드로 분기하기
+        if (uri.startsWith("/user")) {
             requestHandler = new UserRequestHandler();
         }else{
             requestHandler = new HomeRequestHandler();

--- a/src/main/java/webserver/RequestController.java
+++ b/src/main/java/webserver/RequestController.java
@@ -34,7 +34,7 @@ public class RequestController implements Runnable {
     public void handleRequest(HttpRequest httpRequest, OutputStream out) throws IOException {
         String uri = httpRequest.getUri();
         RequestHandler requestHandler;
-        if (uri.startsWith("/user")) {
+        if (uri.startsWith("/user")) { //todo get, post메서드로 분기하기
             requestHandler = new UserRequestHandler();
         }else{
             requestHandler = new HomeRequestHandler();

--- a/src/main/java/webserver/RequestController.java
+++ b/src/main/java/webserver/RequestController.java
@@ -24,7 +24,7 @@ public class RequestController implements Runnable {
                 connection.getPort());
 
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
-            HttpRequest httpRequest = HttpRequestFactory.getRequest(in);
+			HttpRequest httpRequest = HttpRequestFactory.getRequest(in);
             httpRequest.logHeaders();
             handleRequest(httpRequest, out);
         } catch (IOException e) {

--- a/src/main/java/webserver/RequestController.java
+++ b/src/main/java/webserver/RequestController.java
@@ -25,7 +25,7 @@ public class RequestController implements Runnable {
 
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
 			HttpRequest httpRequest = HttpRequestFactory.getRequest(in);
-            httpRequest.logHeaders();
+			httpRequest.logHeaders();
             handleRequest(httpRequest, out);
         } catch (IOException e) {
             logger.error(e.getMessage());

--- a/src/main/resources/templates/user/form.html
+++ b/src/main/resources/templates/user/form.html
@@ -75,7 +75,7 @@
 <div class="container" id="main">
    <div class="col-md-6 col-md-offset-3">
       <div class="panel panel-default content-main">
-          <form name="question" method="get" action="/user/create">
+          <form name="question" method="post" action="/user/create">
               <div class="form-group">
                   <label for="userId">사용자 아이디</label>
                   <input class="form-control" id="userId" name="userId" placeholder="User ID">

--- a/src/test/java/handler/UserRequestHandlerTest.java
+++ b/src/test/java/handler/UserRequestHandlerTest.java
@@ -8,6 +8,8 @@ import model.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+
 import static org.assertj.core.api.Assertions.*;
 
 class UserRequestHandlerTest {
@@ -17,11 +19,12 @@ class UserRequestHandlerTest {
 	void 회원가입시_db_저장() {
 		//given
 		RequestHandler requestHandler = new UserRequestHandler();
+		String body = "userId=hello&password=sdd&name=swk&email=test@naver.com";
 		HttpRequest httpRequest = new HttpRequestBuilder()
-			.method("GET")
+			.method("POST")
 			.uri("/user/create")
-			.queryString("userId=hello&password=sdd&name=swk&email=test@naver.com")
 			.version("HTTP/1.1")
+			.body(body)
 			.build();
 
 		//when

--- a/src/test/java/util/HttpRequestHeaderUtilsTest.java
+++ b/src/test/java/util/HttpRequestHeaderUtilsTest.java
@@ -30,12 +30,13 @@ public class HttpRequestHeaderUtilsTest {
 
     private String getNoQueryStringRequestMessage() {
         StringBuilder sb = new StringBuilder();
-        sb.append("GET /index.html HTTP/1.1").append("\r\n");
+        sb.append("GET /user/create HTTP/1.1").append("\r\n");
         sb.append("Host: localhost:8080").append("\r\n");
         sb.append("Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8").append("\r\n");
         sb.append("User-Agent: Mozilla/4.0(compatible; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322; InfoPath.1)").append("\r\n");
         sb.append("Cookie: Idea-14db9320=4d059d9c-532a-48d2-8ebe-3a46dcd4402f").append("\r\n");
         sb.append("\r\n");
+		sb.append("userId=hello&password=asd&name=swk&email=test@naver.com");
 
         return sb.toString();
     }


### PR DESCRIPTION
## 구현 내용
1. POST 메서드로 회원가입 구현
    - form.html 파일의 form 태그 method를 get에서 post로 수정했다.
    - 요청 body읽기 위해 content-length 필드 사용했다.
    - body 내용 저장하기 위해 HttpRequest String type의 body 필드를 추가했다.

2. 리다이렉션
    - 회원가입 완료후 302 상태코드 응답 메시지 클라이언트에게 보낸다.
    - 리다이렉트 페이지 Location 헤더 필드에 명시했다.

## 고민 사항
- 요청 메시지의 body를 읽을 때 br.readLine()으로 읽으니까 오류가 발생해서 br.read(char[] buf) 함수를 사용해서 content-length 만큼 body를 읽었다. 자세한 내용은 readme 파일에 정리했다.

- 요청 메시지 바디는 String으로 저장하고 응답 메시지 바디는 byte[] 타입으로 저장했다.

- HttpRequest, HttpResponse 필드에 body가 없는 경우 null 처리를 하기위해 Optional을 감쌌는데 오히려 필요없는 코드가 생기고 빈문자열이나 빈배열을 넣는게 더 자연스럽다고 생각해서 Optional을 없앴다.



## 기타
- 이제 요청 메서드 종류가 GET과 POST가 돼서 리다이렉션을 써서 매핑을 처리할까 고민중이다.
