### PR TITLE
[Win-9] step-3 다양한 컨텐츠 타입 지원

### DIFF
--- a/src/main/java/controller/FrontController.java
+++ b/src/main/java/controller/FrontController.java
@@ -33,7 +33,7 @@ public class FrontController {
             ResourceDto resource = PathHandler.responseResource(requestHeader.getMethod(), requestHeader.getPath(), controller);
             response = CommonResponse.onOk(resource.getHttpStatus(), ResourceHandler.resolveResource(resource), resource.getExtension());
         } catch (SourceException e) {
-            response = CommonResponse.onFail(e.getErrorCode().getHttpStatus(), e.getMessage(), ".html");
+            response = CommonResponse.onFail(e.getErrorCode().getHttpStatus(), e.getMessage());
         } finally {
             return response;
         }

--- a/src/main/java/controller/FrontController.java
+++ b/src/main/java/controller/FrontController.java
@@ -1,5 +1,13 @@
 package controller;
 
+import dto.ResourceDto;
+import exception.SourceException;
+import model.CommonResponse;
+import util.ResourceHandler;
+import webserver.PathHandler;
+import webserver.RequestHeader;
+
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -12,7 +20,26 @@ public class FrontController {
         controllerMap.put("/user/form.html", new UserController());
     }
 
-    public static UserController getController(String path) {
+    public static CommonResponse service(RequestHeader requestHeader) throws IOException {
+        // controller Mapping
+        UserController controller = getController(requestHeader.getPath());
+        CommonResponse response = getResponse(requestHeader, controller);
+        return response;
+    }
+
+    private static CommonResponse getResponse(RequestHeader requestHeader, UserController controller) {
+        CommonResponse response = null;
+        try {
+            ResourceDto resource = PathHandler.responseResource(requestHeader.getMethod(), requestHeader.getPath(), controller);
+            response = CommonResponse.onOk(resource.getHttpStatus(), ResourceHandler.resolveResource(resource), resource.getExtension());
+        } catch (SourceException e) {
+            response = CommonResponse.onFail(e.getErrorCode().getHttpStatus(), e.getMessage(), ".html");
+        } finally {
+            return response;
+        }
+    }
+
+    private static UserController getController(String path) {
         for (String key : controllerMap.keySet()) {
             if (path.startsWith(key)) {
                 return controllerMap.get(key);

--- a/src/main/java/controller/FrontController.java
+++ b/src/main/java/controller/FrontController.java
@@ -1,6 +1,7 @@
 package controller;
 
 import dto.ResourceDto;
+import exception.ExceptionHandler;
 import exception.SourceException;
 import model.CommonResponse;
 import util.ResourceHandler;
@@ -33,7 +34,7 @@ public class FrontController {
             ResourceDto resource = PathHandler.responseResource(requestHeader.getMethod(), requestHeader.getPath(), controller);
             response = CommonResponse.onOk(resource.getHttpStatus(), ResourceHandler.resolveResource(resource), resource.getExtension());
         } catch (SourceException e) {
-            response = CommonResponse.onFail(e.getErrorCode().getHttpStatus(), e.getMessage());
+            response = ExceptionHandler.handleGeneralException(e);
         } finally {
             return response;
         }

--- a/src/main/java/controller/UserController.java
+++ b/src/main/java/controller/UserController.java
@@ -4,15 +4,38 @@ import dto.ResourceDto;
 import model.QueryParams;
 import service.UserService;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
 public class UserController {
     private final UserService userService = new UserService();
+    private Map<String, Function<Object, ResourceDto>> methodMap =  new HashMap<>();
 
-    public ResourceDto process(QueryParams queryParams) {
-        userService.createUser(queryParams);
+    {
+        methodMap.put("/user/create", this::generateUserResource);
+        methodMap.put("/index.html", this::process);
+        methodMap.put("/user/form.html", this::process);
+    }
+
+
+    public ResourceDto generateUserResource(Object queryParams) {
+        userService.createUser((QueryParams) queryParams);
         return ResourceDto.of("/index.html", 302);
     }
 
-    public ResourceDto process(String path) {
-        return ResourceDto.of(path);
+    public ResourceDto process(Object path) {
+        return ResourceDto.of((String) path);
     }
+
+    public Function<Object, ResourceDto> getCorrectMethod(String path) {
+        for (String key : methodMap.keySet()) {
+            if (path.startsWith(key)) {
+                return methodMap.get(key);
+            }
+        }
+        return null;
+    }
+
+
 }

--- a/src/main/java/controller/UserController.java
+++ b/src/main/java/controller/UserController.java
@@ -1,7 +1,7 @@
 package controller;
 
 import dto.ResourceDto;
-import model.QueryParams;
+import util.QueryParams;
 import service.UserService;
 
 import java.util.HashMap;

--- a/src/main/java/dto/ResourceDto.java
+++ b/src/main/java/dto/ResourceDto.java
@@ -31,4 +31,9 @@ public class ResourceDto {
     public HttpStatus getHttpStatus() {
         return httpStatus;
     }
+
+    public String getExtension() {
+        int dotIndex = path.lastIndexOf(".");
+        return path.substring(dotIndex + 1);
+    }
 }

--- a/src/main/java/exception/ExceptionHandler.java
+++ b/src/main/java/exception/ExceptionHandler.java
@@ -3,7 +3,7 @@ package exception;
 import model.CommonResponse;
 
 public class ExceptionHandler {
-    private static CommonResponse handleGeneralException(SourceException e){
+    public static CommonResponse handleGeneralException(SourceException e){
         return CommonResponse.onFail(e.getErrorCode().getHttpStatus(), e.getMessage());
     }
 }

--- a/src/main/java/model/CommonResponse.java
+++ b/src/main/java/model/CommonResponse.java
@@ -5,7 +5,7 @@ import util.HttpStatus;
 public class CommonResponse {
     private HttpStatus httpStatus;
     private byte[] body;
-    private String extension = ".html";
+    private String extension = "html";
 
     private CommonResponse(HttpStatus httpStatus, byte[] body, String extension){
         this.httpStatus = httpStatus;

--- a/src/main/java/model/CommonResponse.java
+++ b/src/main/java/model/CommonResponse.java
@@ -5,6 +5,13 @@ import util.HttpStatus;
 public class CommonResponse {
     private HttpStatus httpStatus;
     private byte[] body;
+    private String extension = ".html";
+
+    private CommonResponse(HttpStatus httpStatus, byte[] body, String extension){
+        this.httpStatus = httpStatus;
+        this.body = body;
+        this.extension = extension;
+    }
 
     private CommonResponse(HttpStatus httpStatus, byte[] body){
         this.httpStatus = httpStatus;
@@ -19,8 +26,12 @@ public class CommonResponse {
         return httpStatus;
     }
 
-    public static CommonResponse onOk(HttpStatus httpStatus, byte[] body){
-        return new CommonResponse(httpStatus, body);
+    public String getExtension() {
+        return extension;
+    }
+
+    public static CommonResponse onOk(HttpStatus httpStatus, byte[] body, String extension){
+        return new CommonResponse(httpStatus, body, extension);
     }
 
     public static CommonResponse onFail(HttpStatus httpStatus, String message){

--- a/src/main/java/service/UserService.java
+++ b/src/main/java/service/UserService.java
@@ -13,7 +13,7 @@ import java.util.Map;
 public class UserService {
     private static final Logger logger = LoggerFactory.getLogger(UserService.class);
 
-    public void createUser(QueryParams queryParams) {
+    public User createUser(QueryParams queryParams) {
         User user = new User();
         Map<String, String> paramMap = queryParams.getParamMap();
         for (String key: paramMap.keySet()) {
@@ -25,6 +25,7 @@ public class UserService {
         }
         Database.addUser(user);
         logger.debug("DataBase Size = {}", Database.findAll().size());
+        return user;
     }
 
 }

--- a/src/main/java/service/UserService.java
+++ b/src/main/java/service/UserService.java
@@ -2,7 +2,7 @@ package service;
 
 import db.Database;
 import exception.SourceException;
-import model.QueryParams;
+import util.QueryParams;
 import model.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/util/QueryParam.java
+++ b/src/main/java/util/QueryParam.java
@@ -1,4 +1,4 @@
-package model;
+package util;
 
 public class QueryParam {
     private String key;

--- a/src/main/java/util/QueryParams.java
+++ b/src/main/java/util/QueryParams.java
@@ -1,4 +1,4 @@
-package model;
+package util;
 
 import java.util.Arrays;
 import java.util.Map;

--- a/src/main/java/util/ResponseBuilder.java
+++ b/src/main/java/util/ResponseBuilder.java
@@ -9,9 +9,9 @@ import java.io.IOException;
 public class ResponseBuilder {
     private static final Logger logger = LoggerFactory.getLogger(ResponseBuilder.class);
 
-    public static void sendResponse(DataOutputStream dos, byte[] body, HttpStatus httpStatus) throws IOException {
+    public static void sendResponse(DataOutputStream dos, byte[] body, HttpStatus httpStatus, String extension) throws IOException {
         try {
-            sendHeader(dos, httpStatus, body.length);
+            sendHeader(dos, httpStatus, body.length, extension);
             dos.write(body, 0, body.length);
             dos.flush();
         } catch (IOException e) {
@@ -19,9 +19,9 @@ public class ResponseBuilder {
         }
     }
 
-    public static void sendHeader(DataOutputStream dos, HttpStatus httpStatus, int bodyLength) throws IOException {
+    public static void sendHeader(DataOutputStream dos, HttpStatus httpStatus, int bodyLength, String extension) throws IOException {
         dos.writeBytes("HTTP/1.1  " + httpStatus.getCode() + " " + httpStatus.getMessage() + "\r\n");
-        dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
+        dos.writeBytes("Content-Type: text/" + extension + ";charset=utf-8\r\n");
         dos.writeBytes("Content-Length: " + bodyLength + "\r\n");
         dos.writeBytes("\r\n");
     }

--- a/src/main/java/webserver/PathHandler.java
+++ b/src/main/java/webserver/PathHandler.java
@@ -4,18 +4,19 @@ import controller.UserController;
 import dto.ResourceDto;
 import model.QueryParams;
 
-import java.io.IOException;
+import java.util.function.Function;
 
 public class PathHandler {
 
-    public static ResourceDto responseResource(String method, String path, UserController controller) throws IOException {
+    public static ResourceDto responseResource(String method, String path, UserController controller) {
         if (controller != null) {
+            Function<Object, ResourceDto> correctMethod = controller.getCorrectMethod(path);
             if (method.equals("GET") && path.contains("?")) {
                 String[] splits = path.split("\\?");
                 QueryParams queryParams = QueryParams.from(splits[1]);
-                return controller.process(queryParams);
+                return correctMethod.apply(queryParams);
             } else if (method.equals("GET")) {
-                return controller.process(path);
+                return correctMethod.apply(path);
             }
         }
 

--- a/src/main/java/webserver/PathHandler.java
+++ b/src/main/java/webserver/PathHandler.java
@@ -2,7 +2,7 @@ package webserver;
 
 import controller.UserController;
 import dto.ResourceDto;
-import model.QueryParams;
+import util.QueryParams;
 
 import java.util.function.Function;
 

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -41,24 +41,11 @@ public class RequestHandler implements Runnable {
 
             RequestHeader requestHeader = readRequest(br);
 
-            UserController controller = FrontController.getController(requestHeader.getPath());
+            CommonResponse response = FrontController.service(requestHeader);
 
-            CommonResponse response = getResponse(requestHeader, controller);
-            ResponseBuilder.sendResponse(dos, response.getBody(), response.getHttpStatus());
+            ResponseBuilder.sendResponse(dos, response.getBody(), response.getHttpStatus(), response.getExtension());
         } catch (ClassNotFoundException | IOException e) {
             logger.error(e.getMessage());
-        }
-    }
-
-    private static CommonResponse getResponse(RequestHeader requestHeader, UserController controller) throws IOException {
-        CommonResponse response = null;
-        try {
-            ResourceDto resource = PathHandler.responseResource(requestHeader.getMethod(), requestHeader.getPath(), controller);
-            response = CommonResponse.onOk(resource.getHttpStatus(), ResourceHandler.resolveResource(resource));
-        } catch (SourceException e) {
-            response = CommonResponse.onFail(e.getErrorCode().getHttpStatus(), e.getMessage());
-        } finally {
-            return response;
         }
     }
 

--- a/src/test/java/controller/FrontControllerTest.java
+++ b/src/test/java/controller/FrontControllerTest.java
@@ -1,0 +1,59 @@
+package controller;
+
+import model.CommonResponse;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import util.HttpStatus;
+import webserver.RequestHeader;
+
+import java.io.IOException;
+
+class FrontControllerTest {
+
+
+    @Test
+    @DisplayName("정상 url 응답 테스트")
+    public void validUrlServiceTest() throws IOException {
+        // given
+        RequestHeader header = createHeader("GET", "/index.html", "HTTP/1.1");
+
+        // when
+        CommonResponse response = FrontController.service(header);
+
+        // then
+        Assertions.assertEquals("html", response.getExtension());
+        Assertions.assertEquals(HttpStatus.OK, response.getHttpStatus());
+    }
+
+    @Test
+    @DisplayName("잘못된 url 요청 응답 테스트")
+    public void notValidUrlServiceTest() throws IOException {
+        // given
+        RequestHeader header = createHeader("GET", "/bad.html", "HTTP/1.1");
+
+        // when
+        CommonResponse response = FrontController.service(header);
+
+        // then
+        Assertions.assertEquals(HttpStatus.NOT_FOUND, response.getHttpStatus());
+    }
+
+    @Test
+    @DisplayName("잘못된 static 자원 요청 응답 테스트")
+    public void notValidResourceServiceTest() throws IOException {
+        // given
+        RequestHeader header = createHeader("GET", "/css/badcss.css", "HTTP/1.1");
+
+        // when
+        CommonResponse response = FrontController.service(header);
+
+        // then
+        Assertions.assertEquals(HttpStatus.NOT_FOUND, response.getHttpStatus());
+    }
+
+    private RequestHeader createHeader(String method, String path, String protocol) {
+        return new RequestHeader(method, path, protocol);
+    }
+
+}

--- a/src/test/java/service/UserServiceTest.java
+++ b/src/test/java/service/UserServiceTest.java
@@ -1,7 +1,7 @@
 package service;
 
 import exception.SourceException;
-import model.QueryParams;
+import util.QueryParams;
 import model.User;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/service/UserServiceTest.java
+++ b/src/test/java/service/UserServiceTest.java
@@ -13,9 +13,13 @@ public class UserServiceTest {
     @Test
     @DisplayName("사용자 생성 성공 테스트")
     public void createUserTest() {
+        // given
         QueryParams queryParams = QueryParams.from("userId=javajigi&password=password&name=jaesung&email=javajigi@slipp.net");
+
+        // when
         User user = userService.createUser(queryParams);
 
+        // then
         Assertions.assertEquals("jaesung", user.getName());
         Assertions.assertEquals("javajigi@slipp.net", user.getEmail());
     }
@@ -23,9 +27,13 @@ public class UserServiceTest {
     @Test
     @DisplayName("중복 사용자 저장 예외 테스트")
     public void duplicatedUserExceptionTest() {
+        // given
         QueryParams firstQueryParams = QueryParams.from("userId=win9&password=password&name=seunggu&email=win9@gmail.com");
+
+        // when
         userService.createUser(firstQueryParams);
 
+        // then
         Assertions.assertThrows(SourceException.class, () -> userService.createUser(firstQueryParams));
     }
 }

--- a/src/test/java/service/UserServiceTest.java
+++ b/src/test/java/service/UserServiceTest.java
@@ -1,0 +1,31 @@
+package service;
+
+import exception.SourceException;
+import model.QueryParams;
+import model.User;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class UserServiceTest {
+    private final UserService userService = new UserService();
+
+    @Test
+    @DisplayName("사용자 생성 성공 테스트")
+    public void createUserTest() {
+        QueryParams queryParams = QueryParams.from("userId=javajigi&password=password&name=jaesung&email=javajigi@slipp.net");
+        User user = userService.createUser(queryParams);
+
+        Assertions.assertEquals("jaesung", user.getName());
+        Assertions.assertEquals("javajigi@slipp.net", user.getEmail());
+    }
+
+    @Test
+    @DisplayName("중복 사용자 저장 예외 테스트")
+    public void duplicatedUserExceptionTest() {
+        QueryParams firstQueryParams = QueryParams.from("userId=win9&password=password&name=seunggu&email=win9@gmail.com");
+        userService.createUser(firstQueryParams);
+
+        Assertions.assertThrows(SourceException.class, () -> userService.createUser(firstQueryParams));
+    }
+}

--- a/src/test/java/util/ResourceHandlerTest.java
+++ b/src/test/java/util/ResourceHandlerTest.java
@@ -1,0 +1,78 @@
+package util;
+
+import dto.ResourceDto;
+import exception.SourceException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+
+class ResourceHandlerTest {
+
+    @Nested
+    @DisplayName("ResourceHandler 리소스 요청 메소드")
+    class ResourceRequest {
+
+        @Nested
+        @DisplayName("존재하는 자원을 요청하면")
+        class ExistResource {
+            @Test
+            @DisplayName("css static 자원을 반환한다.")
+            public void cssSourceResolveTest() throws IOException {
+                // given
+                ResourceDto resourceDto = ResourceDto.of("/css/styles.css");
+
+                // when
+                byte[] resource = ResourceHandler.resolveResource(resourceDto);
+
+                // then
+                Assertions.assertNotNull(resource);
+            }
+
+            @Test
+            @DisplayName("js static 자원을 반환한다")
+            public void jsSourceResolveTest() throws IOException {
+                // given
+                ResourceDto resourceDto = ResourceDto.of("/js/scripts.js");
+
+                // when
+                byte[] resource = ResourceHandler.resolveResource(resourceDto);
+
+                // then
+                Assertions.assertNotNull(resource);
+            }
+
+            @Test
+            @DisplayName("html templates 자원을 반환한다")
+            public void htmlSourceResolveTest() throws IOException {
+                // given
+                ResourceDto resourceDto = ResourceDto.of("/index.html");
+
+                // when
+                byte[] resource = ResourceHandler.resolveResource(resourceDto);
+
+                // then
+                Assertions.assertNotNull(resource);
+            }
+        }
+
+        @Nested
+        @DisplayName("존재하지 않는 자원을 요청하면")
+        class NotExistResource {
+            @Test
+            @DisplayName("예외가 발생한다.")
+            public void cssSourceResolveTest() {
+                // given
+                ResourceDto resourceDto = ResourceDto.of("/css/bad.css");
+
+                // when & then
+                Assertions.assertThrows(SourceException.class, () -> ResourceHandler.resolveResource(resourceDto));
+            }
+        }
+
+    }
+
+}


### PR DESCRIPTION
## 구현 내용

### Controller 리팩토링

기존 FrontController에서는 역할이 집중되지 못한다는 단점이 있었습니다.    
구현하려는 FrontController의 역할은 모든 것을 가운데서 중계하는 역할이었습니다.   
처리 가능한 Controller를 찾아서 가져온 후 이를 처리하며, 의도한 View를 찾아오는 Resolver를 호출하는 역할을 합니다.   

그러나 현재 구현한 FrontContorller에서는 요청한 Path에 대해서 처리 가능한 controller를 가져오는 역할만 수행하였습니다.   
이는 RequestHandler에서 모든 것을 처리하고 있었기에 책임을 분리하지 못하고 모든 역할을 수행하고 있었습니다.   

따라서 RequestHadler에서는 요청에 대한 초기 처리와 마지막 응답에 대해서만 관장하도록 하고, 나머지 역할을
FrontController에서 수행하게 하여 의도된 설계대로 구현하려 하였습니다.

### 다양한 컨텐츠 타입 지원

html이 아닌 css, js, img...등등의 다양한 타입의 요청에 대해서는 Content-Type을 맞추어야 합니다.   
기존에는 파일/html의 형식으로 모든 것들을 html로 인식하고 있기 때문에 css와 js, img에 대해서 올바른 타입을    
구분할 수 없었습니다. 헤더의 path경로에서 요청한 리소스의 확장자를 파싱하여 타입을 따오도록 하였습니다.   

### Exception Handler

발생한 에러에 대한 Exception에 대해서 기존에는 fail응답을 내려주었습니다.    
에러에 대한 전체적인 응답을 여기서 처리할 수 있도록 이를 구현하여 다른 곳에서의 에러 처리의 책임을   
분리하도록 하였습니다.

### Test

행위에 대한 테스트를 진행하기 위한 BDD테스트를 수행하였습니다.   
후에 있는 미션을 수행하면서 기능을 추가하며 테스트 기능에 대해 더

---
## 고민 사항

### 한정된 Content-Type

* 고민사항
> 현재 헤더를 파싱하여 요청한 경로의 확장자를 파싱하여 Content-Type을 맞춰주고 있습니다.   
따라서 현재로는 js, css, img에 관한 요청은 문제가 없지만, 후에 woff2, svg와 같이 확장자와 타입이  
다른 요청이 오게 된다면 Mime-Type이 정상적이지 못한 응답을 하게 될 것입니다.   
따라서 보다 더 다양한 타입에 대한 처리가 가능한 방법을 고민중에 있습니다.


### Test 의존성

* 고민사항
> 테스트에 관한 외부 라이브러리를 사용하지 못하는 제약이 명시되어 있습니다.     
테스트를 수행하다 보니 단순히 파라미터 반복에 대해서 반복된 테스트가 이루어 진다는 것을 확인하였습니다.   
Junit의 다른 의존성을 가져와 사용한다면 중복 작성 필요 없이 파라미터를 변경하는 방식의 작성이 가능합니다.   
더 짜임새 있는 Test를 위해서 외부 의존성을 가져 오는 것이 더 났다고 생각하기 때문에 고민중에 있습니다.


### 테스트 메소드

* 고민사항
> 테스트 전용의 메소드를 구현하는 것은 좋지 않다는 말을 들은 적이 있습니다.   
현재 자바로 구현한 DB Map을 사용하면서 실행시마다 자동 clear가 되기때문에 이와 관련한 메소드를    
구현할 필요가 없었습니다. 그러나 테스트는 순서를 보장하지 않기 때문에, 테스트 수행시 DB에 직접 값을    
넣고 빼면서 의도하지 않는 값이 미리 넣어져 있는 경우가 발생하였습니다. 

> beforeEach를 이용하여 DB를 초기화 시켜주는 메소드를 매 수행시 마다 적용하는 방법을 생각했지만   
테스트 전용의 메소드를 구현하는 것이 과연 좋은 방식인지 고민중입니다.


### BDD 테스트

* 해결
> BDD 테스트를 수행하면서 다양한 수행 방식을 알아보았습니다.   
Given-When-Then과 Describe-Content-It 두가지 방식이 있었는데   
전자의 같은 경우는 보다 테스팅에 대해서 큰 비용 부담 없이 행위를 명시가 가능했고, 후자의 방법은
비용 부담이 있지만 테스트 수행결과를 명확히 볼 수 있다는 장점이 있었습니다.   

> 현재 상황에서는 비용의 부담을 크게 가져가기 보다는 이를 줄이면서 행위를
더 명시적으로 보여주는 방법이 더 좋은 방법이라 생각하여 전자의 방법을 적용하기로 하였습니다.


## 기타

* [공부한 내용을 Wiki로 정리하였습니다.](https://github.com/Win-9/be-was/wiki/Step%E2%80%903)
* 다음 미션에 수행해야하는 Post에 대해서 처리를 어떠한 방식으로 해야 하는지 학습중에 있습니다.



