### PR TITLE
[Win-9] step-4 POST로 회원가입

### DIFF
--- a/src/main/java/controller/FrontController.java
+++ b/src/main/java/controller/FrontController.java
@@ -4,6 +4,7 @@ import dto.ResourceDto;
 import exception.ExceptionHandler;
 import exception.SourceException;
 import model.CommonResponse;
+import request.HttpRequest;
 import util.ResourceHandler;
 import webserver.PathHandler;
 import webserver.RequestHeader;
@@ -21,17 +22,17 @@ public class FrontController {
         controllerMap.put("/user/form.html", new UserController());
     }
 
-    public static CommonResponse service(RequestHeader requestHeader) throws IOException {
+    public static CommonResponse service(HttpRequest httpRequest) throws IOException {
         // controller Mapping
-        UserController controller = getController(requestHeader.getPath());
-        CommonResponse response = getResponse(requestHeader, controller);
+        UserController controller = getController(httpRequest.getRequestHeader().getPath());
+        CommonResponse response = getResponse(httpRequest.getRequestHeader(), httpRequest.getBody(),controller);
         return response;
     }
 
-    private static CommonResponse getResponse(RequestHeader requestHeader, UserController controller) {
+    private static CommonResponse getResponse(RequestHeader requestHeader, byte[] body, UserController controller) {
         CommonResponse response = null;
         try {
-            ResourceDto resource = PathHandler.responseResource(requestHeader.getMethod(), requestHeader.getPath(), controller);
+            ResourceDto resource = PathHandler.responseResource(requestHeader.getMethod(), requestHeader.getPath(), body, controller);
             response = CommonResponse.onOk(resource.getHttpStatus(), ResourceHandler.resolveResource(resource), resource.getExtension());
         } catch (SourceException e) {
             response = ExceptionHandler.handleGeneralException(e);

--- a/src/main/java/controller/FrontController.java
+++ b/src/main/java/controller/FrontController.java
@@ -29,7 +29,7 @@ public class FrontController {
         return response;
     }
 
-    private static CommonResponse getResponse(RequestHeader requestHeader, byte[] body, UserController controller) {
+    private static CommonResponse getResponse(RequestHeader requestHeader, String body, UserController controller) {
         CommonResponse response = null;
         try {
             ResourceDto resource = PathHandler.responseResource(requestHeader.getMethod(), requestHeader.getPath(), body, controller);

--- a/src/main/java/controller/UserController.java
+++ b/src/main/java/controller/UserController.java
@@ -18,7 +18,6 @@ public class UserController {
         methodMap.put("/user/form.html", this::process);
     }
 
-
     public ResourceDto generateUserResource(Object queryParams) {
         userService.createUser((QueryParams) queryParams);
         return ResourceDto.of("/index.html", 302);

--- a/src/main/java/request/HttpRequest.java
+++ b/src/main/java/request/HttpRequest.java
@@ -4,9 +4,9 @@ import webserver.RequestHeader;
 
 public class HttpRequest {
     private RequestHeader requestHeader;
-    private byte[] body;
+    private String body;
 
-    public HttpRequest(RequestHeader requestHeader, byte[] body) {
+    public HttpRequest(RequestHeader requestHeader, String body) {
         this.requestHeader = requestHeader;
         this.body = body;
     }
@@ -15,11 +15,11 @@ public class HttpRequest {
         return requestHeader;
     }
 
-    public byte[] getBody() {
+    public String getBody() {
         return body;
     }
 
-    public static HttpRequest of(RequestHeader requestHeader, byte[] body) {
+    public static HttpRequest of(RequestHeader requestHeader, String body) {
         return new HttpRequest(requestHeader, body);
     }
 }

--- a/src/main/java/request/HttpRequest.java
+++ b/src/main/java/request/HttpRequest.java
@@ -1,0 +1,25 @@
+package request;
+
+import webserver.RequestHeader;
+
+public class HttpRequest {
+    private RequestHeader requestHeader;
+    private byte[] body;
+
+    public HttpRequest(RequestHeader requestHeader, byte[] body) {
+        this.requestHeader = requestHeader;
+        this.body = body;
+    }
+
+    public RequestHeader getRequestHeader() {
+        return requestHeader;
+    }
+
+    public byte[] getBody() {
+        return body;
+    }
+
+    public static HttpRequest of(RequestHeader requestHeader, byte[] body) {
+        return new HttpRequest(requestHeader, body);
+    }
+}

--- a/src/main/java/util/ResourceHandler.java
+++ b/src/main/java/util/ResourceHandler.java
@@ -1,9 +1,12 @@
 package util;
 
+import ch.qos.logback.core.util.FileUtil;
 import dto.ResourceDto;
 import exception.SourceException;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
@@ -12,7 +15,15 @@ public class ResourceHandler {
 
     public static byte[] resolveResource(ResourceDto resource) throws IOException {
         String resourcePath = getResourcePath(resource.getPath());
-        return Files.readAllBytes(new File(resourcePath).toPath());
+        FileInputStream fis = new FileInputStream(resourcePath);
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        byte[] buffer = new byte[1024];
+        int read;
+        while ((read = fis.read(buffer)) != -1) {
+            bos.write(buffer, 0, read);
+        }
+        fis.close();
+        return bos.toByteArray();
     }
 
     private static String getResourcePath(String path) {

--- a/src/main/java/util/ResponseBuilder.java
+++ b/src/main/java/util/ResponseBuilder.java
@@ -21,6 +21,9 @@ public class ResponseBuilder {
 
     public static void sendHeader(DataOutputStream dos, HttpStatus httpStatus, int bodyLength, String extension) throws IOException {
         dos.writeBytes("HTTP/1.1  " + httpStatus.getCode() + " " + httpStatus.getMessage() + "\r\n");
+        if (httpStatus == HttpStatus.REDIRECT) {
+            dos.writeBytes("Location: http://localhost:8080/index.html\r\n");
+        }
         dos.writeBytes("Content-Type: text/" + extension + ";charset=utf-8\r\n");
         dos.writeBytes("Content-Length: " + bodyLength + "\r\n");
         dos.writeBytes("\r\n");

--- a/src/main/java/webserver/PathHandler.java
+++ b/src/main/java/webserver/PathHandler.java
@@ -8,10 +8,14 @@ import java.util.function.Function;
 
 public class PathHandler {
 
-    public static ResourceDto responseResource(String method, String path, UserController controller) {
+    public static ResourceDto responseResource(String method, String path, String body, UserController controller) {
         if (controller != null) {
             Function<Object, ResourceDto> correctMethod = controller.getCorrectMethod(path);
-            if (method.equals("GET") && path.contains("?")) {
+            if (method.equals("POST")) {
+                QueryParams queryParam = QueryParams.from(body);
+                return correctMethod.apply(queryParam);
+            }
+            else if (method.equals("GET") && path.contains("?")) {
                 String[] splits = path.split("\\?");
                 QueryParams queryParams = QueryParams.from(splits[1]);
                 return correctMethod.apply(queryParams);

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -37,7 +37,9 @@ public class RequestHandler implements Runnable {
             BufferedReader br = new BufferedReader(new InputStreamReader(in, "UTF-8"));
 
             RequestHeader requestHeader = readRequest(br);
-            byte[] body = parseBody(in, requestHeader.getContentLength().length());
+            String body = parseBody(br, Integer.parseInt(requestHeader.getContentLength()));
+            System.out.println("body = " + body);
+
             HttpRequest httpRequest = HttpRequest.of(requestHeader, body);
 
             CommonResponse response = FrontController.service(httpRequest);
@@ -48,21 +50,12 @@ public class RequestHandler implements Runnable {
         }
     }
 
-    private byte[] parseBody(InputStream in, int contentLength) throws IOException {
-        byte[] body = null;
-
-        System.out.println("contentLength = " + contentLength);
+    private String parseBody(BufferedReader br, int contentLength) throws IOException {
+        char[] chArr = new char[contentLength];
         if (contentLength != 0) {
-            body = new byte[contentLength];
-            int bytesRead = 0;
-            while (bytesRead < contentLength) {
-                System.out.println("strt");
-                bytesRead += in.read(body, bytesRead, contentLength - bytesRead);
-            }
-            System.out.println("body = " + body.length);
+            br.read(chArr);
         }
-
-        return body;
+        return URLDecoder.decode(new String(chArr), StandardCharsets.UTF_8);
     }
 
     private RequestHeader readRequest(BufferedReader br) throws IOException, ClassNotFoundException {

--- a/src/main/java/webserver/RequestHeader.java
+++ b/src/main/java/webserver/RequestHeader.java
@@ -13,6 +13,7 @@ public class RequestHeader {
     private String connection;
     private String accept;
     private String referer;
+    private String contentLength;
 
     private static final Logger logger = LoggerFactory.getLogger(RequestHeader.class);
 
@@ -20,6 +21,7 @@ public class RequestHeader {
         this.method = method;
         this.path = path;
         this.protocol = protocol;
+        this.contentLength = "";
     }
 
     public String getPath() {
@@ -28,6 +30,10 @@ public class RequestHeader {
 
     public String getMethod() {
         return method;
+    }
+
+    public String getContentLength() {
+        return contentLength;
     }
 
     public static void setHeader(RequestHeader requestHeader, String key, String value) {

--- a/src/main/java/webserver/RequestHeader.java
+++ b/src/main/java/webserver/RequestHeader.java
@@ -21,7 +21,7 @@ public class RequestHeader {
         this.method = method;
         this.path = path;
         this.protocol = protocol;
-        this.contentLength = "";
+        this.contentLength = "0";
     }
 
     public String getPath() {

--- a/src/main/resources/templates/user/form.html
+++ b/src/main/resources/templates/user/form.html
@@ -75,7 +75,7 @@
 <div class="container" id="main">
    <div class="col-md-6 col-md-offset-3">
       <div class="panel panel-default content-main">
-          <form name="question" method="get" action="/user/create">
+          <form name="question" method="post" action="/user/create">
               <div class="form-group">
                   <label for="userId">사용자 아이디</label>
                   <input class="form-control" id="userId" name="userId" placeholder="User ID">

--- a/src/test/java/controller/FrontControllerTest.java
+++ b/src/test/java/controller/FrontControllerTest.java
@@ -4,6 +4,7 @@ import model.CommonResponse;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import request.HttpRequest;
 import util.HttpStatus;
 import webserver.RequestHeader;
 
@@ -16,10 +17,10 @@ class FrontControllerTest {
     @DisplayName("정상 url 응답 테스트")
     public void validUrlServiceTest() throws IOException {
         // given
-        RequestHeader header = createHeader("GET", "/index.html", "HTTP/1.1");
+        HttpRequest request = HttpRequest.of(createHeader("GET", "/index.html", "HTTP/1.1"), "dummyData");
 
         // when
-        CommonResponse response = FrontController.service(header);
+        CommonResponse response = FrontController.service(request);
 
         // then
         Assertions.assertEquals("html", response.getExtension());
@@ -30,10 +31,10 @@ class FrontControllerTest {
     @DisplayName("잘못된 url 요청 응답 테스트")
     public void notValidUrlServiceTest() throws IOException {
         // given
-        RequestHeader header = createHeader("GET", "/bad.html", "HTTP/1.1");
+        HttpRequest request = HttpRequest.of(createHeader("GET", "/index/bad", "HTTP/1.1"), "dummyData");
 
         // when
-        CommonResponse response = FrontController.service(header);
+        CommonResponse response = FrontController.service(request);
 
         // then
         Assertions.assertEquals(HttpStatus.NOT_FOUND, response.getHttpStatus());
@@ -43,10 +44,11 @@ class FrontControllerTest {
     @DisplayName("잘못된 static 자원 요청 응답 테스트")
     public void notValidResourceServiceTest() throws IOException {
         // given
-        RequestHeader header = createHeader("GET", "/css/badcss.css", "HTTP/1.1");
+        HttpRequest request = HttpRequest.of(createHeader("GET", "/css/badcss.css", "HTTP/1.1"), "dummyData");
+
 
         // when
-        CommonResponse response = FrontController.service(header);
+        CommonResponse response = FrontController.service(request);
 
         // then
         Assertions.assertEquals(HttpStatus.NOT_FOUND, response.getHttpStatus());

--- a/src/test/java/controller/FrontControllerTest.java
+++ b/src/test/java/controller/FrontControllerTest.java
@@ -54,6 +54,34 @@ class FrontControllerTest {
         Assertions.assertEquals(HttpStatus.NOT_FOUND, response.getHttpStatus());
     }
 
+    @Test
+    @DisplayName("Post 정상 url 성공 테스트")
+    public void postRequestServiceTest() throws IOException {
+        // given
+        String body = "userId=win9&password=password&name=seunggu&email=win9@gmail.com";
+        HttpRequest request = HttpRequest.of(createHeader("POST", "/user/create", "HTTP/1.1"), body);
+
+        // when
+        CommonResponse response = FrontController.service(request);
+
+        // then
+        Assertions.assertEquals(HttpStatus.REDIRECT, response.getHttpStatus());
+    }
+
+    @Test
+    @DisplayName("Post 비정상 url 예외 테스트")
+    public void notValidPostRequestServiceTest() throws IOException {
+        // given
+        String body = "userId=win9&password=password&name=seunggu&email=win9@gmail.com";
+        HttpRequest request = HttpRequest.of(createHeader("POST", "/user/bad", "HTTP/1.1"), body);
+
+        // when
+        CommonResponse response = FrontController.service(request);
+
+        // then
+        Assertions.assertEquals(HttpStatus.NOT_FOUND, response.getHttpStatus());
+    }
+
     private RequestHeader createHeader(String method, String path, String protocol) {
         return new RequestHeader(method, path, protocol);
     }

--- a/src/test/java/webserver/RequestHandlerTest.java
+++ b/src/test/java/webserver/RequestHandlerTest.java
@@ -1,0 +1,38 @@
+package webserver;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.*;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.Socket;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RequestHandlerTest {
+
+    @Test
+    @DisplayName("Body 내용을 stream으로 성공적으로 읽는지 테스트")
+    public void bodyParseTest() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, InstantiationException, IOException {
+        // given
+        String bodyData = "userId=javajigi&password=password&name=jaesung&email=javajigi@slipp.net";
+        InputStream is = new ByteArrayInputStream(bodyData.getBytes());
+
+        // read it with BufferedReader
+        BufferedReader br = new BufferedReader(new InputStreamReader(is));
+
+        Class<RequestHandler> requestHandlerClass = RequestHandler.class;
+        RequestHandler requestHandler = new RequestHandler(new Socket());
+
+        Method parseBodyMethod = requestHandlerClass.getDeclaredMethod("parseBody", BufferedReader.class, int.class);
+        parseBodyMethod.setAccessible(true);
+
+        // when
+        String result = (String) parseBodyMethod.invoke(requestHandler, br, bodyData.length());
+
+        // then
+        Assertions.assertEquals(bodyData, result);
+    }
+}


### PR DESCRIPTION
## 구현 내용

### Request Body

HTTP Form에서 POST 메소드로 요청시 Http Body의 값을 읽기 위해서는 헤더의 Content-Length의 값을 알아야 했습니다.
현재 Reflection으로 구성된 헤더 파싱부분에 대해서 Content-Length에 값이 null로 값이 들어가는 점을 알게 되었습니다.

따라서 헤더 객체가 생성시 default 값으로 0을 가지도록 하였습니다. 또한 정적 자원에 대해서는 Length의 값이 0이기 때문에
Length값이 0이 아닐시에 파싱을 시도하도록 하였습니다.

파싱시 IO패키지의 BufferedReader를 이용하여 Body를 읽어 값을 가져오도록 하였습니다.
이렇게 가져온 Body와 Header의 값을 Controller에 넘겨주기 위하여 HttpRequest객체를 만들어

필요한 데이터를 선택하여 가져올 수 있도록 하였습니다. 이에 선택된 Controller에서는 PathHandler를 거쳐 Get과 Post요청에 따라
바디, 쿼리스트링, 일반 요청을 구분하여 상황에 맞는 메소드를 실행할 수 있게 되었습니다.


### NIO

요청을 읽어오는 과정은 BufferedReader와 InpuStream을 사용하면서 IO를 사용하였고, 
요청한 파일에 대해서 정적 및 동적파일을 읽어오는 과정에서는 NIO메소드인readAllBytes를 사용하면서 NIO를 사용하고 있었습니다. 

NIO를 IO로 대체하기 위해서 IO패키지의 FileInputStream을 사용하여 이를 읽어오는 방식을 적용하여 대체하였습니다.


### Redirection

회원가입 이후의 요청에 대해서 `index.html`의 경로로 redirect 처리를 하였습니다.
Controller에서 로직 호출 이후 view리소스를 return하는 ResourceDto 생성과정에서 default 값인 HttpStatus.OK에서
302를 추가하게 되면 값을 담고 있다가 마지막에 CommonseRespose 객체에  status가 전달되도록 하였습니다.

이후 ResponseBulider에서 HttpReponse를 만드는 과정에서 이 값이 전달되어 Header Location에 의도한 경로가 
들어갈 수 있도록 하였습니다.

> 현재는 한정적 redirection 경로만이 가능하여 다양한 경로에 대한 유연한 처리가 필요하다고 생각됩니다. 

## 고민 사항

### BufferedReader

httpBody의 경우 텍스트뿐만 아니라 binary데이터가 담겨서 올 수 있습니다.   
이때 내부 버퍼사용과 인코딩 문제로 의도하지 않은 에러가 발생할 수 있습니다.

따라서 InputStream 사용을 지향하고 있습니다.
[Http Body 읽기](https://github.com/Win-9/be-was/wiki/Step-4#http-body%EC%9D%BD%EA%B8%B0)

* 고민사항
> InputStream을 이용하여 값을 읽어 올 때 byte에서 String으로 인코딩시 
글이 깨져서 데이터를 처리하는데 문제가 발생하였습니다. 이를 해결할 수 있는 방안을 모색중입니다.


### Test시의 의존

* 고민사항
> RequestHandler의 private메소드를 테스트를 할 때 자바 리플렉션을 사용하였습니다.
이때 method.invoke()를 사용하기 위해서 위하여 강제로 생성자를 불러와 instance로 사용하였습니다.

> New Connection을 생성하여 값을 주입해야하므로 테스트시 너무 많은 의존성을 가지고 있습니다.
따라서 의존성을 분리하여 테스트를 수행할 수 있는 방법을 찾고 있습니다.



### IO와 NIO

* 고민사항

> 현재 구현하는 WAS의 경우 IO와 NIO의 처리중 어느 선택이 더 효율적인가?

* 해결

> NIO는 다수의 Channel들을 하나의 thread를 사용해서 관리할 수 있으므로 scalability가 좋고, 비동기 방식이므로 데이터 처리는 좀 더 복잡한 처리 과정을 거친다.

> IO는 버퍼를 생성하지 않고 즉시 처리하므로, 클라이언트가 적고 대용량 처리를 할 경우에 더 적합하다.

> 현재 구현하는 WAS의 경우 적은 클라이언트이며, 다수의 파일들을 요구하므로 IO처리 방식이 더 적합하고 판단된다.


## 기타

* [공부한 내용을 위키로 정리하였습니다.](https://github.com/Win-9/be-was/wiki/Step-4)

이전의 고민사항[#161]에 대한 고민을 해보았습니다.   

1. 한정된 Content-Type

확장자 인식 이후 미리 담겨진 Map데이터에서 매핑을 통하여 이를 결정할 수 있도록 합니다. 
> 현재 apache에서는 매우 다양한 타입에 대한 매핑파일을 따로두어 이를 매핑하는 방식을 사용하고 있습니다.

3. 테스트 메소드

필요하다면 테스트를 위한 메소드를 작성하는 것도 하나의 방법입니다. 
하지만 이런 경우에는 그런 메소드가 실제 로직에 영향을 주지 않도록 주의해야 합니다.   

단일 책임 원칙에 따라 각 클래스와 메소드는 하나의 책임만을 가져야 합니다. 
테스트가 프로덕션 코드에 영향을 주지 않도록 주의하고, 테스트 후에는 반드시 제거하도록 하는것이 좋습니다.