### PR TITLE
[Win-9] step-5 쿠키를 이용한 로그인 

### DIFF
--- a/src/main/java/controller/FrontController.java
+++ b/src/main/java/controller/FrontController.java
@@ -20,6 +20,7 @@ public class FrontController {
         controllerMap.put("/user/create", new UserController());
         controllerMap.put("/index.html", new UserController());
         controllerMap.put("/user/form.html", new UserController());
+        controllerMap.put("/user/login", new UserController());
     }
 
     public static CommonResponse service(HttpRequest httpRequest) throws IOException {

--- a/src/main/java/controller/FrontController.java
+++ b/src/main/java/controller/FrontController.java
@@ -20,6 +20,7 @@ public class FrontController {
         controllerMap.put("/user/create", new UserController());
         controllerMap.put("/index.html", new UserController());
         controllerMap.put("/user/form.html", new UserController());
+        controllerMap.put("/user/login.html", new UserController());
         controllerMap.put("/user/login", new UserController());
     }
 
@@ -27,6 +28,7 @@ public class FrontController {
         // controller Mapping
         UserController controller = getController(httpRequest.getRequestHeader().getPath());
         CommonResponse response = getResponse(httpRequest.getRequestHeader(), httpRequest.getBody(),controller);
+        response.setPath(response.getPath());
         return response;
     }
 
@@ -34,7 +36,8 @@ public class FrontController {
         CommonResponse response = null;
         try {
             ResourceDto resource = PathHandler.responseResource(requestHeader.getMethod(), requestHeader.getPath(), body, controller);
-            response = CommonResponse.onOk(resource.getHttpStatus(), ResourceHandler.resolveResource(resource), resource.getExtension());
+            response = CommonResponse.onOk(resource.getHttpStatus(), ResourceHandler.resolveResource(resource),
+                    resource.getExtension(), resource.getPath());
         } catch (SourceException e) {
             response = ExceptionHandler.handleGeneralException(e);
         } finally {

--- a/src/main/java/controller/UserController.java
+++ b/src/main/java/controller/UserController.java
@@ -7,6 +7,7 @@ import service.UserService;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 
 public class UserController {
@@ -23,6 +24,9 @@ public class UserController {
 
     public ResourceDto loginUserResource(Object bodyData) {
         String sessionId = userService.loginUser((QueryParams) bodyData);
+        if (sessionId == null) {
+            return ResourceDto.of("/user/login_failed.html", 302);
+        }
         Model.addAttribute("sessionId", sessionId);
         return ResourceDto.of("/index.html", 302);
     }

--- a/src/main/java/controller/UserController.java
+++ b/src/main/java/controller/UserController.java
@@ -1,6 +1,7 @@
 package controller;
 
 import dto.ResourceDto;
+import model.Model;
 import util.QueryParams;
 import service.UserService;
 
@@ -16,6 +17,13 @@ public class UserController {
         methodMap.put("/user/create", this::generateUserResource);
         methodMap.put("/index.html", this::process);
         methodMap.put("/user/form.html", this::process);
+        methodMap.put("/user/login", this::loginUserResource);
+    }
+
+    public ResourceDto loginUserResource(Object bodyData) {
+        String sessionId = userService.loginUser((QueryParams) bodyData);
+        Model.addAttribute("sessionId", sessionId);
+        return ResourceDto.of("/index.html", 302);
     }
 
     public ResourceDto generateUserResource(Object queryParams) {
@@ -35,6 +43,4 @@ public class UserController {
         }
         return null;
     }
-
-
 }

--- a/src/main/java/controller/UserController.java
+++ b/src/main/java/controller/UserController.java
@@ -20,6 +20,8 @@ public class UserController {
         methodMap.put("/user/form.html", this::process);
         methodMap.put("/user/login.html", this::process);
         methodMap.put("/user/login", this::loginUserResource);
+        methodMap.put("/user/login_failed.html", this::process);
+
     }
 
     public ResourceDto loginUserResource(Object bodyData) {

--- a/src/main/java/controller/UserController.java
+++ b/src/main/java/controller/UserController.java
@@ -17,6 +17,7 @@ public class UserController {
         methodMap.put("/user/create", this::generateUserResource);
         methodMap.put("/index.html", this::process);
         methodMap.put("/user/form.html", this::process);
+        methodMap.put("/user/login.html", this::process);
         methodMap.put("/user/login", this::loginUserResource);
     }
 
@@ -37,7 +38,7 @@ public class UserController {
 
     public Function<Object, ResourceDto> getCorrectMethod(String path) {
         for (String key : methodMap.keySet()) {
-            if (path.startsWith(key)) {
+            if (path.matches(key)) {
                 return methodMap.get(key);
             }
         }

--- a/src/main/java/db/Database.java
+++ b/src/main/java/db/Database.java
@@ -3,18 +3,17 @@ package db;
 import com.google.common.collect.Maps;
 
 import model.User;
+import util.Session;
 
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Map;
 
 public class Database {
     private static Map<String, User> users = Maps.newHashMap();
-    private static Map<String, String> sessoinDB = Maps.newConcurrentMap();
+    private static Map<String, Session> sessoinDB = Maps.newConcurrentMap();
 
-    public static void addSession(String UUID, String userId) {
-        sessoinDB.put(UUID, userId);
-    }
-
+    // User
     public static void addUser(User user) {
         users.put(user.getUserId(), user);
     }
@@ -25,5 +24,14 @@ public class Database {
 
     public static Collection<User> findAll() {
         return users.values();
+    }
+
+    // Session
+    public static void addSession(Session session) {
+        sessoinDB.put(session.getSessionId(), session);
+    }
+
+    public static Session getSession(String sessionId) {
+        return sessoinDB.get(sessionId);
     }
 }

--- a/src/main/java/db/Database.java
+++ b/src/main/java/db/Database.java
@@ -9,6 +9,11 @@ import java.util.Map;
 
 public class Database {
     private static Map<String, User> users = Maps.newHashMap();
+    private static Map<String, String> sessoinDB = Maps.newConcurrentMap();
+
+    public static void addSession(String UUID, String userId) {
+        sessoinDB.put(UUID, userId);
+    }
 
     public static void addUser(User user) {
         users.put(user.getUserId(), user);

--- a/src/main/java/model/CommonResponse.java
+++ b/src/main/java/model/CommonResponse.java
@@ -5,12 +5,15 @@ import util.HttpStatus;
 public class CommonResponse {
     private HttpStatus httpStatus;
     private byte[] body;
+    private String path;
+
     private String extension = "html";
 
-    private CommonResponse(HttpStatus httpStatus, byte[] body, String extension){
+    private CommonResponse(HttpStatus httpStatus, byte[] body, String extension, String path){
         this.httpStatus = httpStatus;
         this.body = body;
         this.extension = extension;
+        this.path = path;
     }
 
     private CommonResponse(HttpStatus httpStatus, byte[] body){
@@ -26,12 +29,20 @@ public class CommonResponse {
         return httpStatus;
     }
 
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
     public String getExtension() {
         return extension;
     }
 
-    public static CommonResponse onOk(HttpStatus httpStatus, byte[] body, String extension){
-        return new CommonResponse(httpStatus, body, extension);
+    public static CommonResponse onOk(HttpStatus httpStatus, byte[] body, String extension, String path){
+        return new CommonResponse(httpStatus, body, extension, path);
     }
 
     public static CommonResponse onFail(HttpStatus httpStatus, String message){

--- a/src/main/java/model/Model.java
+++ b/src/main/java/model/Model.java
@@ -1,0 +1,17 @@
+package model;
+
+import com.google.common.collect.Maps;
+
+import java.util.Map;
+
+public class Model {
+    public static Map<String, Object> modelMap = Maps.newConcurrentMap();
+
+    public static void addAttribute(String name, Object object) {
+        modelMap.put(name, object);
+    }
+
+    public static Object getAttribute(String name) {
+        return modelMap.get(name);
+    }
+}

--- a/src/main/java/model/Model.java
+++ b/src/main/java/model/Model.java
@@ -3,6 +3,7 @@ package model;
 import com.google.common.collect.Maps;
 
 import java.util.Map;
+import java.util.Optional;
 
 public class Model {
     public static Map<String, Object> modelMap = Maps.newConcurrentMap();
@@ -11,7 +12,7 @@ public class Model {
         modelMap.put(name, object);
     }
 
-    public static Object getAttribute(String name) {
-        return modelMap.get(name);
+    public static Optional<Object> getAttribute(String name) {
+        return Optional.ofNullable(modelMap.get(name));
     }
 }

--- a/src/main/java/service/UserService.java
+++ b/src/main/java/service/UserService.java
@@ -34,11 +34,11 @@ public class UserService {
         Map<String, String> data = bodyData.getParamMap();
         User user = Database.findUserById(data.get("userId"));
         if (user == null) {
-            throw new SourceException(ErrorCode.NOT_EXIST_USER);
+            return null;
         }
 
-        if (!user.getPassword().equals(Database.findUserById(data.get("password")))) {
-            throw new SourceException(ErrorCode.NOT_VALID_PASSWORD);
+        if (!user.getPassword().equals(data.get("password"))) {
+            return null;
         }
         Session session = new Session(user.getUserId());
         Database.addSession(session);

--- a/src/main/java/service/UserService.java
+++ b/src/main/java/service/UserService.java
@@ -7,6 +7,7 @@ import model.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import util.ErrorCode;
+import util.Session;
 
 import java.util.Map;
 import java.util.UUID;
@@ -39,8 +40,8 @@ public class UserService {
         if (!user.getPassword().equals(Database.findUserById(data.get("password")))) {
             throw new SourceException(ErrorCode.NOT_VALID_PASSWORD);
         }
-        String uuid = UUID.randomUUID().toString();
-        Database.addSession(uuid, user.getUserId());
-        return uuid;
+        Session session = new Session(user.getUserId());
+        Database.addSession(session);
+        return session.getSessionId();
     }
 }

--- a/src/main/java/service/UserService.java
+++ b/src/main/java/service/UserService.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import util.ErrorCode;
 
 import java.util.Map;
+import java.util.UUID;
 
 public class UserService {
     private static final Logger logger = LoggerFactory.getLogger(UserService.class);
@@ -28,4 +29,18 @@ public class UserService {
         return user;
     }
 
+    public String loginUser(QueryParams bodyData) {
+        Map<String, String> data = bodyData.getParamMap();
+        User user = Database.findUserById(data.get("userId"));
+        if (user == null) {
+            throw new SourceException(ErrorCode.NOT_EXIST_USER);
+        }
+
+        if (!user.getPassword().equals(Database.findUserById(data.get("password")))) {
+            throw new SourceException(ErrorCode.NOT_VALID_PASSWORD);
+        }
+        String uuid = UUID.randomUUID().toString();
+        Database.addSession(uuid, user.getUserId());
+        return uuid;
+    }
 }

--- a/src/main/java/util/ErrorCode.java
+++ b/src/main/java/util/ErrorCode.java
@@ -3,7 +3,9 @@ package util;
 public enum ErrorCode {
 
     DUPLICATED_USER(HttpStatus.BAD_REQUEST, "존재하는 사용자 입니다."),
-    NOT_VALID_PATH(HttpStatus.NOT_FOUND, "잘못된 요청입니다.");
+    NOT_VALID_PATH(HttpStatus.NOT_FOUND, "잘못된 요청입니다."),
+    NOT_EXIST_USER(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자 입니다."),
+    NOT_VALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/util/ResponseBuilder.java
+++ b/src/main/java/util/ResponseBuilder.java
@@ -47,7 +47,7 @@ public class ResponseBuilder {
     }
 
     private static String formattingDate(LocalDateTime date){
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zz", Locale.ENGLISH);
-        return formatter.format(date);
+        DateTimeFormatter dataFormat = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zz", Locale.ENGLISH);
+        return date.atZone(ZoneId.of("Asia/Seoul")).format(dataFormat);
     }
 }

--- a/src/main/java/util/ResponseBuilder.java
+++ b/src/main/java/util/ResponseBuilder.java
@@ -1,5 +1,6 @@
 package util;
 
+import model.Model;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,6 +27,15 @@ public class ResponseBuilder {
         }
         dos.writeBytes("Content-Type: text/" + extension + ";charset=utf-8\r\n");
         dos.writeBytes("Content-Length: " + bodyLength + "\r\n");
+        Model.getAttribute("sessionId").ifPresent(
+                value -> {
+                    try {
+                        dos.writeBytes("Set-Cookie: sid=" + value + "; Path=/\r\n");
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+        );
         dos.writeBytes("\r\n");
     }
 }

--- a/src/main/java/util/ResponseBuilder.java
+++ b/src/main/java/util/ResponseBuilder.java
@@ -1,18 +1,23 @@
 package util;
 
+import db.Database;
 import model.Model;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
 public class ResponseBuilder {
     private static final Logger logger = LoggerFactory.getLogger(ResponseBuilder.class);
 
-    public static void sendResponse(DataOutputStream dos, byte[] body, HttpStatus httpStatus, String extension) throws IOException {
+    public static void sendResponse(DataOutputStream dos, byte[] body, String path, HttpStatus httpStatus, String extension) throws IOException {
         try {
-            sendHeader(dos, httpStatus, body.length, extension);
+            sendHeader(dos, httpStatus, path, body.length, extension);
             dos.write(body, 0, body.length);
             dos.flush();
         } catch (IOException e) {
@@ -20,22 +25,29 @@ public class ResponseBuilder {
         }
     }
 
-    public static void sendHeader(DataOutputStream dos, HttpStatus httpStatus, int bodyLength, String extension) throws IOException {
+    public static void sendHeader(DataOutputStream dos, HttpStatus httpStatus, String path, int bodyLength, String extension) throws IOException {
         dos.writeBytes("HTTP/1.1  " + httpStatus.getCode() + " " + httpStatus.getMessage() + "\r\n");
         if (httpStatus == HttpStatus.REDIRECT) {
-            dos.writeBytes("Location: http://localhost:8080/index.html\r\n");
+            dos.writeBytes("Location: http://localhost:8080" + path + "\r\n");
         }
         dos.writeBytes("Content-Type: text/" + extension + ";charset=utf-8\r\n");
         dos.writeBytes("Content-Length: " + bodyLength + "\r\n");
         Model.getAttribute("sessionId").ifPresent(
                 value -> {
+                    String stringValue = String.valueOf(value);
                     try {
-                        dos.writeBytes("Set-Cookie: sid=" + value + "; Path=/\r\n");
+                        dos.writeBytes("Set-Cookie: sid=" + stringValue + "; Expires="
+                                + formattingDate(Database.getSession(stringValue).getExpires()) + "; Path=/");
                     } catch (IOException e) {
                         throw new RuntimeException(e);
                     }
                 }
         );
         dos.writeBytes("\r\n");
+    }
+
+    private static String formattingDate(LocalDateTime date){
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zz", Locale.ENGLISH);
+        return formatter.format(date);
     }
 }

--- a/src/main/java/util/Session.java
+++ b/src/main/java/util/Session.java
@@ -1,0 +1,26 @@
+package util;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public class Session {
+    private String sessionId;
+    private String userId;
+    private LocalDateTime createTime;
+    private LocalDateTime expires;
+
+    public Session(String userId) {
+        this.sessionId = UUID.randomUUID().toString();
+        this.userId = userId;
+        this.createTime = LocalDateTime.now();
+        this.expires = createTime.plusMinutes(10);
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public LocalDateTime getExpires() {
+        return expires;
+    }
+}

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -38,13 +38,12 @@ public class RequestHandler implements Runnable {
 
             RequestHeader requestHeader = readRequest(br);
             String body = parseBody(br, Integer.parseInt(requestHeader.getContentLength()));
-            System.out.println("body = " + body);
 
             HttpRequest httpRequest = HttpRequest.of(requestHeader, body);
 
             CommonResponse response = FrontController.service(httpRequest);
 
-            ResponseBuilder.sendResponse(dos, response.getBody(), response.getHttpStatus(), response.getExtension());
+            ResponseBuilder.sendResponse(dos, response.getBody(), response.getPath(), response.getHttpStatus(), response.getExtension());
         } catch (ClassNotFoundException | IOException e) {
             logger.error(e.getMessage());
         }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -29,7 +29,6 @@ public class RequestHandler implements Runnable {
     public void run() {
         logger.debug("New Client Connect! Connected IP : {}, Port : {}", connection.getInetAddress(),
                 connection.getPort());
-//        public static final Map<String, Function<P, R>> REQUEST_MAP = new HashMap<>();
 
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
             // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
@@ -42,7 +41,6 @@ public class RequestHandler implements Runnable {
             HttpRequest httpRequest = HttpRequest.of(requestHeader, body);
 
             CommonResponse response = FrontController.service(httpRequest);
-
             ResponseBuilder.sendResponse(dos, response.getBody(), response.getPath(), response.getHttpStatus(), response.getExtension());
         } catch (ClassNotFoundException | IOException e) {
             logger.error(e.getMessage());

--- a/src/main/java/webserver/RequestHeader.java
+++ b/src/main/java/webserver/RequestHeader.java
@@ -14,6 +14,7 @@ public class RequestHeader {
     private String accept;
     private String referer;
     private String contentLength;
+    private String cookie;
 
     private static final Logger logger = LoggerFactory.getLogger(RequestHeader.class);
 
@@ -53,7 +54,9 @@ public class RequestHeader {
                 "\n path = " + path +
                 "\n protocol = " + protocol +
                 "\n host = " + host +
+                "\n cookie = " + cookie +
                 "\n connection = " +  connection +
+                "\n Content-length = " +  contentLength +
                 "\n accpet = " + accept +
                 "\n referer = " + referer + "\n===");
     }


### PR DESCRIPTION
**PR 보낼때 위 내용은 모두 삭제하고 보내세요.**

## 구현 내용

### Session

응답 시 사용자를 구분하지 못하는 문제가 발생하였습니다. 따라서 로그인 이후에 SesionDB를 이용하여 사용자의 ID와 고유한 SessionID를 매핑정보를 저장하고 응답시 Session ID 정보를 담는 쿠키를 보내 무상태성을 가지는 HTTP가 사용자 정보를 유지할 수 있도록 하였습니다.   

메소드의 호출 깊이 가 깊어짐에 따라서 Model객체를 중간에 사용하여 기타 정보들을 저장할 수 있도록 하였습니다.    
해당 객체에 세션 정보를 저장하여 ResponseBuilder에 해당 객체의 정보를 뽑아서 사용할 수 있도록 하였습니다.

### 로그인 실패

비즈니스 로직을 담는 Serivce층에서 로그인에 대한 실패 처리를 구현하였습니다. 로그인 실패 시 Session을 생성하지 않고 에러페이지로    
redirection이 되도록 하였습니다. 

---


## 고민 사항

### 마감과 품질

* 고민사항
> 구현한 로직들이 복잡해지면서 구조적인 리펙토링이 필요하다고 느껴집니다.    
OOP의 원칙에 따라 역할들을 분리하여 확장성있고 유지보수가 가능하도록 재 설계가 필요하다고 생각합니다.   
코드의 품질을 높이는 것과 기간 내의 구현중 어느 것이 더 가치있는 것인지 다시끔 고민해보도록 하는 과정을 겪고 있습니다.   

### Static

* 고민사항
> 메소드 깊이가 깊어질수록 전달하려는 파라미터가 늘어나게되고, 이를 해결하고차 Static에 대한 사용이 많아지게 되었습니다.   
Static을 자주사용하는 것이 성능에서 큰 차이가 없는지, OOP의 원칙에서는 어긋나지 않는지 또는 
어떠한 방식이 더 좋은 방향인지 또한 다른 좋은 방향성이 있는지 고민하고 있습니다.



## 기타

* 사용자의 정보에 따른 동적 HTML을 구현하기 위하여 해당 파일을 어떻게 파싱하고 응답을 내릴 수 있을 지, 어떠한 역할을 분리해야 하는지 구현하고 있습니다.


