### PR TITLE
[Hymin2] step-5 쿠키를 이용한 로그인

### DIFF
--- a/src/main/java/controller/UserController.java
+++ b/src/main/java/controller/UserController.java
@@ -9,6 +9,10 @@ import webserver.annotation.PostMapping;
 import webserver.annotation.RequestBody;
 import webserver.annotation.RequestParam;
 import webserver.response.Response;
+import webserver.session.Session;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class UserController {
     private static final Logger logger = LoggerFactory.getLogger(UserController.class);
@@ -31,5 +35,13 @@ public class UserController {
         userService.createUser(register);
 
         return Response.redirect("/index.html");
+    }
+
+    @PostMapping(path = "/user/login")
+    public Response login(@RequestBody UserRequest.Login loginInfo){
+        Session session = userService.login(loginInfo);
+
+        logger.debug(session.toString());
+        return Response.redirect("/index.html", session);
     }
 }

--- a/src/main/java/db/Database.java
+++ b/src/main/java/db/Database.java
@@ -5,9 +5,10 @@ import model.User;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class Database {
-    private static Map<String, User> users = Maps.newHashMap();
+    private static final Map<String, User> users = new ConcurrentHashMap<>();
 
     public static void addUser(User user) {
         users.put(user.getUserId(), user);

--- a/src/main/java/dto/UserRequest.java
+++ b/src/main/java/dto/UserRequest.java
@@ -25,4 +25,19 @@ public class UserRequest {
             return email;
         }
     }
+
+    public static class Login{
+        private String userId;
+        private String password;
+
+        public Login(){}
+
+        public String getUserId(){
+            return userId;
+        }
+
+        public String getPassword(){
+            return password;
+        }
+    }
 }

--- a/src/main/java/service/UserService.java
+++ b/src/main/java/service/UserService.java
@@ -5,7 +5,11 @@ import dto.UserRequest;
 import model.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import webserver.exception.GeneralException;
+import webserver.exception.LoginFailedException;
 import webserver.exception.UserIdAlreadyExistsException;
+import webserver.session.Session;
+import webserver.session.SessionManager;
 import webserver.status.ErrorCode;
 
 public class UserService {
@@ -45,6 +49,23 @@ public class UserService {
         Database.addUser(user);
         logger.debug("User 생성 완료");
         logger.debug(user.toString());
+    }
+
+    public Session login(UserRequest.Login loginInfo){
+        if(!existsUserId(loginInfo.getUserId())){
+            throw new LoginFailedException(ErrorCode.LOGIN_FAILED_ERROR);
+        }
+
+        User user = Database.findUserById(loginInfo.getUserId());
+
+        if(!user.getPassword().equals(loginInfo.getPassword())){
+            throw new LoginFailedException(ErrorCode.LOGIN_FAILED_ERROR);
+        }
+
+        Session session = SessionManager.createSession(loginInfo.getUserId());
+        SessionManager.save(session);
+
+        return session;
     }
 
     public User findUser(String userId){

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -3,6 +3,7 @@ package webserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import webserver.handler.RequestHandler;
+import webserver.session.SessionScheduler;
 
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -21,6 +22,7 @@ public class WebServer {
             port = Integer.parseInt(args[0]);
         }
 
+        SessionScheduler.registerSessionScheduler();
         ExecutorService executorService = Executors.newCachedThreadPool();
 
         // 서버소켓을 생성한다. 웹서버는 기본적으로 8080번 포트를 사용한다.

--- a/src/main/java/webserver/adapter/MethodRequestAdapter.java
+++ b/src/main/java/webserver/adapter/MethodRequestAdapter.java
@@ -22,26 +22,6 @@ public abstract class MethodRequestAdapter implements Adapter{
         return method.invoke(instance, params);
     }
 
-    protected Object[] createParams(Method method, Request request) throws InstantiationException, IllegalAccessException {
-        Parameter[] parameters = method.getParameters();
-
-        Object[] params = new Object[parameters.length];
-        int index = 0;
-
-        for(Parameter parameter: parameters){
-            if(parameter.isAnnotationPresent(RequestParam.class)){
-                RequestParam annotation = parameter.getAnnotation(RequestParam.class);
-                params[index++] = request.getParam(annotation.name());
-            } else if(parameter.isAnnotationPresent(RequestBody.class)){
-                params[index++] = createObjectInstance(parameter.getType(), request);
-            }else{
-                params[index++] = null;
-            }
-        }
-
-        return params;
-    }
-
     protected Method findMethod(Class<? extends Annotation> annotation, String path){
         List<Class<?>> classes = ControllerRegistry.getControllers();
 
@@ -58,7 +38,27 @@ public abstract class MethodRequestAdapter implements Adapter{
         return null;
     }
 
-    private Object createObjectInstance(Class<?> type, Request request) throws InstantiationException, IllegalAccessException {
+    protected Object[] createParams(Method method, Request request) throws InstantiationException, IllegalAccessException {
+        Parameter[] parameters = method.getParameters();
+
+        Object[] params = new Object[parameters.length];
+        int index = 0;
+
+        for(Parameter parameter: parameters){
+            if(parameter.isAnnotationPresent(RequestParam.class)){
+                RequestParam annotation = parameter.getAnnotation(RequestParam.class);
+                params[index++] = request.getParam(annotation.name());
+            } else if(parameter.isAnnotationPresent(RequestBody.class)){
+                params[index++] = createResponseBody(parameter.getType(), request);
+            }else{
+                params[index++] = null;
+            }
+        }
+
+        return params;
+    }
+
+    private Object createResponseBody(Class<?> type, Request request) throws InstantiationException, IllegalAccessException {
         Object o = type.newInstance();
 
         Field[] fields = o.getClass().getDeclaredFields();

--- a/src/main/java/webserver/exception/LoginFailedException.java
+++ b/src/main/java/webserver/exception/LoginFailedException.java
@@ -1,0 +1,9 @@
+package webserver.exception;
+
+import webserver.status.ErrorCode;
+
+public class LoginFailedException extends GeneralException{
+    public LoginFailedException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/webserver/handler/ExceptionHandler.java
+++ b/src/main/java/webserver/handler/ExceptionHandler.java
@@ -1,6 +1,7 @@
 package webserver.handler;
 
 import webserver.exception.GeneralException;
+import webserver.exception.LoginFailedException;
 import webserver.exception.UserIdAlreadyExistsException;
 import webserver.response.Response;
 import webserver.status.ErrorCode;
@@ -9,12 +10,17 @@ public class ExceptionHandler {
     public static Response handle(Throwable e){
         if(e instanceof UserIdAlreadyExistsException){
             return handleUserIdAlreadyExistsException();
-        }
-        else if(e instanceof GeneralException){
+        } else if(e instanceof LoginFailedException){
+            return handleLoginFailedException();
+        } else if(e instanceof GeneralException){
             return handleGeneralException((GeneralException) e);
         } else{
             return handleException();
         }
+    }
+
+    private static Response handleLoginFailedException(){
+        return Response.redirect("/user/login_failed.html");
     }
 
     private static Response handleUserIdAlreadyExistsException(){

--- a/src/main/java/webserver/parser/RequestParser.java
+++ b/src/main/java/webserver/parser/RequestParser.java
@@ -47,7 +47,6 @@ public class RequestParser {
 
         while(br.ready()) {
             requestLine = br.readLine();
-            logger.debug(String.valueOf(requestLine.isEmpty()) + br.ready());
 
             if(requestLine.isEmpty()){
                 if(br.ready()) {

--- a/src/main/java/webserver/response/Response.java
+++ b/src/main/java/webserver/response/Response.java
@@ -1,5 +1,6 @@
 package webserver.response;
 
+import webserver.session.Session;
 import webserver.status.HttpStatus;
 import webserver.type.ContentType;
 
@@ -39,6 +40,12 @@ public class Response {
     public static Response redirect(String location){
         return new Response(HttpStatus.FOUND, null)
                 .setHeader("Location", location);
+    }
+
+    public static Response redirect(String location, Session session){
+        return new Response(HttpStatus.FOUND, null)
+                .setHeader("Location", location)
+                .setHeader("Set-Cookie", session.toString());
     }
 
     public static Response onSuccess(byte[] body){

--- a/src/main/java/webserver/session/Session.java
+++ b/src/main/java/webserver/session/Session.java
@@ -1,0 +1,79 @@
+package webserver.session;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+public class Session {
+    private final String id;
+    private final String userId;
+    private final Map<String, String> attributes;
+    private final LocalDateTime expiredTime;
+
+    private Session(Builder builder){
+        this.id = builder.id;
+        this.userId = builder.userId;
+        this.attributes = builder.attributes;
+        this.expiredTime = builder.expiredTime;
+    }
+
+    static Builder builder(){
+        return new Builder();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public boolean isExpired(){
+        return LocalDateTime.now().isAfter(expiredTime);
+    }
+
+    @Override
+    public String toString(){
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("sid=").append(id);
+        attributes.forEach((key, value) -> sb.append("; ").append(key).append("=").append(value));
+
+        return sb.toString();
+    }
+
+    static class Builder{
+        private String id;
+        private String userId;
+        private Map<String, String> attributes;
+        private LocalDateTime expiredTime;
+
+        private Builder(){
+            attributes = new HashMap<>();
+        }
+
+        public Builder id(String id){
+            this.id = id;
+
+            return this;
+        }
+
+        public Builder userId(String userid){
+            this.userId = userid;
+
+            return this;
+        }
+
+        public Builder maxAge(int maxAge){
+            expiredTime = LocalDateTime.now().plusSeconds(maxAge);
+            attributes.put("MaxAge", String.valueOf(maxAge));
+
+            return this;
+        }
+
+        public Session build(){
+            return new Session(this);
+        }
+    }
+}

--- a/src/main/java/webserver/session/SessionDatabase.java
+++ b/src/main/java/webserver/session/SessionDatabase.java
@@ -3,8 +3,10 @@ package webserver.session;
 import webserver.session.Session;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 public class SessionDatabase {
     private static final Map<String, Session> sessions = new ConcurrentHashMap<>();
@@ -15,6 +17,13 @@ public class SessionDatabase {
     public static void addSession(Session session){
         sessions.put(session.getId(), session);
         userSession.put(session.getUserId(), session.getId());
+    }
+
+    public static List<Session> findExpiredSession(){
+        return sessions.values()
+                .stream()
+                .filter(Session::isExpired)
+                .collect(Collectors.toList());
     }
 
     public static Session loadSession(String sessionId){

--- a/src/main/java/webserver/session/SessionDatabase.java
+++ b/src/main/java/webserver/session/SessionDatabase.java
@@ -1,0 +1,34 @@
+package webserver.session;
+
+import webserver.session.Session;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class SessionDatabase {
+    private static final Map<String, Session> sessions = new ConcurrentHashMap<>();
+    private static final Map<String, String> userSession = new ConcurrentHashMap<>();
+
+    private SessionDatabase(){}
+
+    public static void addSession(Session session){
+        sessions.put(session.getId(), session);
+        userSession.put(session.getUserId(), session.getId());
+    }
+
+    public static Session loadSession(String sessionId){
+        return sessions.getOrDefault(sessionId, null);
+    }
+
+    public static boolean existsUserSession(String userId){
+        return userSession.containsKey(userId);
+    }
+
+    public static void deleteSession(String sessionId){
+        Session session = sessions.get(sessionId);
+
+        userSession.remove(session.getUserId());
+        sessions.remove(sessionId);
+    }
+}

--- a/src/main/java/webserver/session/SessionManager.java
+++ b/src/main/java/webserver/session/SessionManager.java
@@ -1,0 +1,35 @@
+package webserver.session;
+
+import java.util.UUID;
+
+public class SessionManager {
+    private static final Integer DEFAULT_MAX_AGE = 60 * 30;
+
+    public static Session createSession(String userId){
+        String sid = UUID.randomUUID().toString();
+
+        return Session.builder()
+                .id(sid)
+                .userId(userId)
+                .maxAge(DEFAULT_MAX_AGE)
+                .build();
+    }
+
+    public static Session createSession(String userId, int maxAge){
+        String sid = UUID.randomUUID().toString();
+
+        return Session.builder()
+                .id(sid)
+                .userId(userId)
+                .maxAge(maxAge)
+                .build();
+    }
+
+    public static void save(Session session){
+        SessionDatabase.addSession(session);
+    }
+
+    public static void delete(Session session){
+        SessionDatabase.deleteSession(session.getId());
+    }
+}

--- a/src/main/java/webserver/session/SessionScheduler.java
+++ b/src/main/java/webserver/session/SessionScheduler.java
@@ -1,0 +1,25 @@
+package webserver.session;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class SessionScheduler {
+    private static final Logger logger = LoggerFactory.getLogger(SessionScheduler.class);
+    private static final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+
+    public static void registerSessionScheduler(){
+        scheduler.scheduleAtFixedRate(SessionScheduler::removeExpiredSessions, 0, 1, TimeUnit.MINUTES);
+    }
+
+    private static void removeExpiredSessions(){
+        List<Session> expiredSessions = SessionDatabase.findExpiredSession();
+
+        expiredSessions.forEach((session) -> SessionDatabase.deleteSession(session.getId()));
+        logger.debug("[Session Scheduler] 만료된 세션 삭제");
+    }
+}

--- a/src/main/java/webserver/status/ErrorCode.java
+++ b/src/main/java/webserver/status/ErrorCode.java
@@ -4,6 +4,7 @@ public enum ErrorCode {
     RESOURCE_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "요청하신 데이터를 찾을 수 없습니다."),
     ILLEGAL_ARGUMENT_ERROR(HttpStatus.BAD_REQUEST, "잘못된 입력입니다."),
     USER_ID_ALREADY_EXISTS_ERROR(HttpStatus.CONFLICT, "현재 사용중인 아이디입니다."),
+    LOGIN_FAILED_ERROR(HttpStatus.BAD_REQUEST, "아이디 또는 비밀번호가 틀립니다. 다시 로그인 해주세요."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러가 발생했습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/test/java/webserver/adapter/ResourceAdapterTest.java
+++ b/src/test/java/webserver/adapter/ResourceAdapterTest.java
@@ -72,7 +72,7 @@ class ResourceAdapterTest {
     }
 
     @Test
-    @DisplayName("/index1.html 파일을 요청할 때 예외 테스트")
+    @DisplayName("/index1.html 파일을 요청할 때 canRun 테스트")
     void cannotRunIndex1Html() {
         Request requestHeader = Request.of("GET", "/index1.html", "HTTP/1.1");
 

--- a/src/test/java/webserver/session/SessionDatabaseTest.java
+++ b/src/test/java/webserver/session/SessionDatabaseTest.java
@@ -1,0 +1,55 @@
+package webserver.session;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SessionDatabaseTest {
+    @Test
+    @DisplayName("세션이 정상적으로 저장되는지 테스트")
+    void sessionTest(){
+        String userId = "user";
+        Session session = SessionManager.createSession(userId);
+
+        SessionDatabase.addSession(session);
+
+        Session sessionFromDatabase = SessionDatabase.loadSession(session.getId());
+
+        assertEquals(session, sessionFromDatabase);
+        assertEquals(true, SessionDatabase.existsUserSession(userId));
+    }
+
+    @Test
+    @DisplayName("만료된 세션들을 정상적으로 반환되는지 테스트")
+    void expiredSessionTest(){
+        String userId1 = "userId";
+        String userId2 = "user";
+
+        Session session1 = SessionManager.createSession(userId1, -1);
+        Session session2 = SessionManager.createSession(userId2, 30);
+
+        SessionDatabase.addSession(session1);
+        SessionDatabase.addSession(session2);
+
+        List<Session> expiredSessions = SessionDatabase.findExpiredSession();
+
+        assertEquals(1, expiredSessions.size());
+        assertEquals(session1, expiredSessions.get(0));
+    }
+
+    @Test
+    @DisplayName("세션들을 정상적으로 삭제하는지 테스트")
+    void deleteSessionTest(){
+        String userId = "userId";
+
+        Session session = SessionManager.createSession(userId);
+
+        SessionDatabase.addSession(session);
+        SessionDatabase.deleteSession(session.getId());
+
+        assertEquals(false, SessionDatabase.existsUserSession(userId));
+    }
+}


### PR DESCRIPTION
## 구현 내용

- 로그인 기능 추가
    - 로그인 성공 시 index.html로 리다이렉트
    - 로그인 성공 시 sid를 쿠키에 담아 응답
        - MaxAge 값을 설정하여 쿠키의 유효 기간을 설정 
    - 로그인 실패 시 /user/login_failed.html로 리다이렉트
- 세션
    - SessionManager를 세션을 생성하고, 데이터베이스에 저장 및 삭제 할 수 있도록 구현
    - 만료된 세션을 일정 주기마다 지우는 스케줄러 추가
 
## 고민 사항

### 세션

세션을 어떻게 관리를 할 것인가가 이번 스텝에서 고민해볼 문제인 것 같습니다. 그냥 로그인할 때 쿠키로 세션 ID를 던져주고, 서버에 저장만 한다면 로그아웃 하기 전까지 세션이 살아 있을 테고, 한 브라우저에서 로그인을 여러 번 하게 된다면 세션은 계속 쌓이게 될 것이라고 생각했습니다. 그래서 저는 
`private final LocalDateTime expiredTime;`
와 같은 필드를 두어 세션이 만들어 졌을 때와 MaxAge 값을 합친 서버 상에서 만료되는 시간을 저장하고, 일정 주기로 동작하는 스케줄러를 두어 만료된 세션을 삭제하는 것으로 구현했습니다. 

하지만 이렇게 되면 일정 시간이 지나면 다시 로그인을 해야되는 상황이 발생합니다. 따라서 활동이 지속되면 세션을 연장하는 기능을 구현해야 할 것 같습니다.

## 기타

### ConcurrentHashMap

세션을 저장할 때 일반 HashMap이 아닌 ConcurrentHashMap을 사용했다. 일반 HashMap을 쓰지 않는 이유는 멀티 쓰레드 환경에서 발생할 수 있는 동시성 문제 때문이다. 아래 예제가 멀티 쓰레드에서 일반 HashMap을 사용했을 때 발생하는 동시성 문제에 대한 예제이다.

``` java
public static void main(String[] args) {
    final Map<String, Integer> hashMap = new HashMap<>();

    // 스레드 1: 1부터 100까지의 값을 HashMap에 추가
    Thread thread1 = new Thread(() -> {
        for (int i = 1; i <= 100; i++) {
            hashMap.put("Key" + i, i);
        }
    });

    // 스레드 2: 101부터 200까지의 값을 HashMap에 추가
    Thread thread2 = new Thread(() -> {
        for (int i = 101; i <= 200; i++) {
            hashMap.put("Key" + i, i);
        }
    });

    thread1.start();
    thread2.start();

    try {
        thread1.join();
        thread2.join();
    } catch (InterruptedException e) {
        e.printStackTrace();
    }

    System.out.println("HashMap size: " + hashMap.size());
    System.out.println("Last value: " + hashMap.get("Key200"));
}
```

위의 코드는 두 쓰레드가 각각 1~100, 101~200까지 HashMap에 저장하고 있는 코드이다. 하지만 이 결과를 보면

```
HashMap size: 196
Last value: 200
```

200개를 저장했지만 실제 사이즈는 196으로 나오게 된다. 이 처럼 HashMap은 멀티 쓰레드 환경에서 내가 원하지 않는 결과를 얻을 수 있다.

위 문제를 해결하기 위한 자료구조는 두 가지가 있다.

하나는 HashTable이고 하나는 ConcurrentHashMap이다. 둘 다 멀티 쓰레드 환경에서 안전하지만, 성능적으로는 차이가 존재한다.

HashTable은 객체에 put을 할 때 마다 lock을 걸어 사용한다. 즉, 객체에 쓰기 작업을 할 때 마다 lock을 획득해야 하고, 그렇지 못하면 기다려야 하는 상황이 생겨 성능상으로 좋진 않다.

반면 ConcurrentHashMap은 HashTable처럼 put을 하면 lock을 걸지만, 특정 세그먼트 또는 버킷 단위로 lock을 걸어 사용한다. 다른 쓰레드가 작업을 하고 있더라도 사용하는 세그먼트나 버킷이 다르면 같이 작업할 수 있는 것이 장점이다. 따라서 HashTable보다 성능적으로 이점이 있다. 하지만 읽기 작업에는 lock을 걸어 사용하지 않기 때문에 다른 쓰레드에서 put이나 remove같은 쓰기 작업을 해도 그 이전의 결과를 가져올 수 있다.